### PR TITLE
Add generate styles script and build boilerplate component

### DIFF
--- a/component-library/components/generic/sample/sample.eleventy.liquid
+++ b/component-library/components/generic/sample/sample.eleventy.liquid
@@ -1,3 +1,8 @@
-<div class="c-sample">
+{% assign c = "c-COMPONENTNAME" %}
+<div class="{{c}} 
+            component 
+            {% if include.background_variant == "Dark" %} 
+                component--dark
+            {% endif %}">
     <p>{{ text }}</p>
 </div>

--- a/component-library/components/generic/sample/sample.scss
+++ b/component-library/components/generic/sample/sample.scss
@@ -1,3 +1,3 @@
-.c-sample {
-    background-color: black;
+.c-COMPONENTNAME {
+    // Component-specific styles
 }

--- a/component-library/shared/styles/global.scss
+++ b/component-library/shared/styles/global.scss
@@ -4,3 +4,14 @@
 html, body {
     
 }
+
+// Default styles applied to all components
+// Component-specific styles are defined within their component directory
+.component {
+	padding: 96px 124px;
+	background-color: var(--light-background-variant);
+
+	&--dark {
+		background-color: var(--dark-background-variant);
+	}
+}

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "generate:styles": "node src/assets/js/generate-styles.js",
     "bookshop-sass:build": "bookshop-sass -b component-library -o src/assets/styles/bookshop.css",
     "bookshop-sass:watch": "bookshop-sass -b component-library -o src/assets/styles/bookshop.css -w",
     "bookshop:browser": "bookshop-browser",
     "bookshop:new": "npx @bookshop/init --component",
 
-    "eleventy:build": "eleventy",
+    "eleventy:build": "generate:styles eleventy",
     "eleventy:watch": "ELEVENTY_ENV=development eleventy --serve",
-    "start": "npm-run-all bookshop-sass:build --parallel bookshop-sass:watch bookshop:browser eleventy:watch"
+    "start": "npm-run-all bookshop-sass:build --parallel generate:styles bookshop-sass:watch bookshop:browser eleventy:watch"
 
   },
   "repository": {

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,0 +1,6 @@
+{
+  "styles": {
+    "light_background_variant": "#3B3B3D",
+    "dark_background_variant": "#1B1B1D"
+  }
+}

--- a/src/_includes/layouts/page.html
+++ b/src/_includes/layouts/page.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {% include 'partials/head/meta.html' %}
-    <link rel="stylesheet" href="/assets/styles/bookshop.css">
+    {% include 'partials/head/stylesheets.html' %}
     <script src="/assets/js/main.js" defer></script>
     <title>{{ title }}</title>
 </head>

--- a/src/_includes/partials/head/stylesheets.html
+++ b/src/_includes/partials/head/stylesheets.html
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="/assets/styles/custom-styles.css">
+<link rel="stylesheet" href="/assets/styles/bookshop.css">

--- a/src/assets/js/generate-styles.js
+++ b/src/assets/js/generate-styles.js
@@ -1,21 +1,21 @@
 const fs = require('fs');
 const path = require('path');
 
-// Global custom styles are generated at build. 
-// If you make local changes within _data/site/styles.json they will not automatically refresh.
+// Global custom styles are generated on build. 
+// If you make local changes to styles within _data/site.json they will not automatically refresh.
 // You will need to rebuild the site for the changes to take effect.
 console.log("🎨 Generating Custom Styles")
 
 // Read JSON data
 const data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../_data/site.json'), 'utf-8'));
 
-// Retrieve the custom object from JSON
+// Retrieve the custom styles from the data file
 const styles = data.styles;
 
 // Initialize CSS string with the :root selector
 let cssString = ':root {\n';
 
-// Loop over all keys in the custom object
+// Loop over all keys in the styles object
 for (let key in styles) {
   // Convert underscores to dashes in the key name
   const cssKey = key.replace(/_/g, '-');

--- a/src/assets/js/generate-styles.js
+++ b/src/assets/js/generate-styles.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+// Global custom styles are generated at build. 
+// If you make local changes within _data/site/styles.json they will not automatically refresh.
+// You will need to rebuild the site for the changes to take effect.
+console.log("🎨 Generating Custom Styles")
+
+// Read JSON data
+const data = JSON.parse(fs.readFileSync(path.join(__dirname, '../../_data/site.json'), 'utf-8'));
+
+// Retrieve the custom object from JSON
+const styles = data.styles;
+
+// Initialize CSS string with the :root selector
+let cssString = ':root {\n';
+
+// Loop over all keys in the custom object
+for (let key in styles) {
+  // Convert underscores to dashes in the key name
+  const cssKey = key.replace(/_/g, '-');
+
+  // Append each key-value pair to the CSS string
+  cssString += `  --${cssKey}: ${styles[key]};\n`;
+}
+
+// Close the :root selector
+cssString += '}\n';
+
+// Write to a CSS file
+fs.writeFileSync(path.join(__dirname, '../styles/custom-styles.css'), cssString);

--- a/src/assets/styles/custom-styles.css
+++ b/src/assets/styles/custom-styles.css
@@ -1,0 +1,4 @@
+:root {
+  --light-background-variant: #3B3B3D;
+  --dark-background-variant: #1B1B1D;
+}


### PR DESCRIPTION
- Added a build script that pulls all user-defined style variables from `_data/site` and turns them into CSS variables.
- Turned the Sample component into a boilerplate component that all components should be derived from