### PR TITLE
PR template - remove generic component test config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,4 @@ The reviewer should check on this branch:
 # Before merge (PR owner)
 
 - Delete the test site in CloudCannon
+- For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,5 +16,5 @@ The reviewer should check on this branch:
 
 # Before merge (PR owner)
 
-- Delete the test site in CloudCannon
-- For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
+- [ ] Delete the test site in CloudCannon
+- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).


### PR DESCRIPTION
# Context

:off-sprint:

# Additional information

We agreed to have
```
  structures:
    - content_blocks
```
For testing generic components. Suggest we add another line to the before merge reminder and change them to checkboxes. See the last section of this PR.

# Testing (tester)

Eyeball the change (its one line) and confirm next time you do a PR.

# Before merge (PR owner)

- [x] Delete the test site in CloudCannon
- [x] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).