### PR TITLE
Refactor/colors

### DIFF
--- a/.cloudcannon/prebuild
+++ b/.cloudcannon/prebuild
@@ -1,5 +1,0 @@
-npm i
-
-npm run fetch-theme-colors
-npm run sass:build
-npm run bookshop-sass:build

--- a/.cloudcannon/prebuild
+++ b/.cloudcannon/prebuild
@@ -1,4 +1,5 @@
 npm i
 
+npm run fetch-theme-colors
 npm run sass:build
 npm run bookshop-sass:build

--- a/.cloudcannon/prebuild
+++ b/.cloudcannon/prebuild
@@ -1,0 +1,3 @@
+npm run fetch-theme-colors
+npm run sass:build
+npm run bookshop-sass:build

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -70,12 +70,12 @@ _inputs:
         icon:
           - key: icon
       values:
-        - name: Dark
-          id: dark
-          icon: dark_mode
-        - name: Light
-          id: light
-          icon: light_mode
+        - name: Primary
+          id: primary
+          icon: star
+        - name: Secondary
+          id: secondary
+          icon: star_outline
 _select_data: {}
 _structures:
   content_blocks:

--- a/component-library/components/generic/button/button.scss
+++ b/component-library/components/generic/button/button.scss
@@ -1,9 +1,8 @@
 .c-button {
-  --_button-color: var(--primary-foreground-color, #f9f9fb);
-
+  color: var(--main-text-color);
   all: unset;
   padding: 1rem 0.75rem;
-  color: var(--_button-color);
+  color: inherit;
   font-size: var(--buttonh);
   font-weight: var(--font-weight-bold);
   line-height: var(--line-height);
@@ -21,21 +20,11 @@
   }
 
   &--primary {
-    border: 2px solid var(--_button-color);
+    border: 2px solid var(--main-text-color);
     &:hover {
-      --_button-color: var(--secondary-background-color, #1b1b1d);
-      border: 2px solid var(--_button-color);
-      background: var(--primary-foreground-color, #f9f9fb);
-    }
-  }
-
-  &[disabled] {
-    --_button-color: var(--brand-grey-600, #6e6e70);
-    pointer-events: none;
-    &:hover {
-      cursor: default;
-      text-decoration: none;
-      background-color: unset;
+      color: var(--alt-text-color);
+      border: 2px solid var(--alt-text-color);
+      background: var(--alt-background-color);
     }
   }
 
@@ -46,6 +35,6 @@
   }
 
   .c-icon__image, .c-icon__svg {
-      --c-icon-color: var(--_button-color);
+      --c-icon-color: var(--main-text-color);
   }
 }

--- a/component-library/components/generic/button/button.scss
+++ b/component-library/components/generic/button/button.scss
@@ -1,5 +1,5 @@
 .c-button {
-  --_button-color: var(--primary-foreground, #f9f9fb);
+  --_button-color: var(--primary-foreground-color, #f9f9fb);
 
   all: unset;
   padding: 1rem 0.75rem;
@@ -23,9 +23,9 @@
   &--primary {
     border: 2px solid var(--_button-color);
     &:hover {
-      --_button-color: var(--secondary-background, #1b1b1d);
+      --_button-color: var(--secondary-background-color, #1b1b1d);
       border: 2px solid var(--_button-color);
-      background: var(--primary-foreground, #f9f9fb);
+      background: var(--primary-foreground-color, #f9f9fb);
     }
   }
 

--- a/component-library/components/generic/button/button.scss
+++ b/component-library/components/generic/button/button.scss
@@ -1,5 +1,5 @@
 .c-button {
-  --_button-color: var(--brand-grey-000, #f9f9fb);
+  --_button-color: var(--primary-foreground, #f9f9fb);
 
   all: unset;
   padding: 1rem 0.75rem;
@@ -23,9 +23,9 @@
   &--primary {
     border: 2px solid var(--_button-color);
     &:hover {
-      --_button-color: var(--brand-grey-900, #1b1b1d);
+      --_button-color: var(--secondary-background, #1b1b1d);
       border: 2px solid var(--_button-color);
-      background: var(--brand-grey-000, #f9f9fb);
+      background: var(--primary-foreground, #f9f9fb);
     }
   }
 

--- a/component-library/components/generic/button/button.scss
+++ b/component-library/components/generic/button/button.scss
@@ -25,6 +25,10 @@
       color: var(--alt-text-color);
       border: 2px solid var(--alt-text-color);
       background: var(--alt-background-color);
+      
+      .c-icon__image, .c-icon__svg {
+        --c-icon-color: var(--alt-text-color);
+      }
     }
   }
 

--- a/component-library/components/generic/button/button.scss
+++ b/component-library/components/generic/button/button.scss
@@ -12,7 +12,7 @@
   align-items: center;
 
   &:focus {
-    outline: 2px solid var(--interaction-blue-300, #2566f2);
+    outline: 2px solid var(--interaction-color, #2566f2);
     outline-offset: -2px;
   }
 

--- a/component-library/components/generic/form/checkbox-group/checkbox-group.eleventy.liquid
+++ b/component-library/components/generic/form/checkbox-group/checkbox-group.eleventy.liquid
@@ -18,7 +18,7 @@
     {% endif %}
 
     <div class="{{ c }}__error error">
-        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-red-300, #BF2323)' %}
+        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
         <p class="{{ c }}__error__text error__text" id="{{ id }}--error">Error Message<p>
     </div>
 </div>

--- a/component-library/components/generic/form/checkbox-group/checkbox-group.eleventy.liquid
+++ b/component-library/components/generic/form/checkbox-group/checkbox-group.eleventy.liquid
@@ -12,7 +12,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/checkbox-group/checkbox-group.eleventy.liquid
+++ b/component-library/components/generic/form/checkbox-group/checkbox-group.eleventy.liquid
@@ -12,7 +12,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/checkbox-group/checkbox-group.scss
+++ b/component-library/components/generic/form/checkbox-group/checkbox-group.scss
@@ -34,7 +34,7 @@
         
     &__error {
         display: none;
-        color: var(--error-red-300, #BF2323);
+        color: var(--error-color, #BF2323);
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);

--- a/component-library/components/generic/form/checkbox-group/checkbox-group.scss
+++ b/component-library/components/generic/form/checkbox-group/checkbox-group.scss
@@ -1,5 +1,5 @@
 .c-checkbox-group {
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -29,7 +29,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/checkbox-group/checkbox-group.scss
+++ b/component-library/components/generic/form/checkbox-group/checkbox-group.scss
@@ -1,5 +1,5 @@
 .c-checkbox-group {
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -29,7 +29,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/checkbox-group/checkbox-group.scss
+++ b/component-library/components/generic/form/checkbox-group/checkbox-group.scss
@@ -1,5 +1,5 @@
 .c-checkbox-group {
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -29,7 +29,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
         
     &__error {

--- a/component-library/components/generic/form/checkbox-input/checkbox-input.scss
+++ b/component-library/components/generic/form/checkbox-input/checkbox-input.scss
@@ -2,13 +2,13 @@
   display: flex;
   gap: 10px;
   align-items: center;
-  color: var(--primary-foreground-color, #F9F9FB);
+  color: var(--main-text-color);
 
   &__input {
     appearance: none;
     width: 16px;
     height: 16px;
-    border: 2px solid var(--primary-foreground-color, #F9F9FB);
+    border: 2px solid var(--main-text-color);
     cursor: pointer;
     position: relative;
     display: flex;
@@ -22,7 +22,7 @@
     }
 
     &:checked:not(:focus) {
-      border: 2px solid var(--primary-foreground-color, #F9F9FB);
+      border: 2px solid var(--main-text-color);
     }
 
     &:focus:checked:after {
@@ -34,7 +34,7 @@
       position: absolute;
       font-size: var(--paragraph-small);
       line-height: var(--paragraph-small);
-      color: var(--primary-foreground-color, #F9F9FB);
+      color: var(--main-text-color);
     }
   }
 

--- a/component-library/components/generic/form/checkbox-input/checkbox-input.scss
+++ b/component-library/components/generic/form/checkbox-input/checkbox-input.scss
@@ -17,7 +17,7 @@
     flex-shrink: 0;
 
     &:focus {
-        border: 2px solid var(--interaction-blue-300, #2566F2);
+        border: 2px solid var(--interaction-color, #2566F2);
         outline: none;
     }
 
@@ -26,7 +26,7 @@
     }
 
     &:focus:checked:after {
-      color: var(--interaction-blue-300, #2566F2);
+      color: var(--interaction-color, #2566F2);
     }
 
     &:checked:after {

--- a/component-library/components/generic/form/checkbox-input/checkbox-input.scss
+++ b/component-library/components/generic/form/checkbox-input/checkbox-input.scss
@@ -2,13 +2,13 @@
   display: flex;
   gap: 10px;
   align-items: center;
-  color: var(--primary-foreground, #F9F9FB);
+  color: var(--primary-foreground-color, #F9F9FB);
 
   &__input {
     appearance: none;
     width: 16px;
     height: 16px;
-    border: 2px solid var(--primary-foreground, #F9F9FB);
+    border: 2px solid var(--primary-foreground-color, #F9F9FB);
     cursor: pointer;
     position: relative;
     display: flex;
@@ -22,7 +22,7 @@
     }
 
     &:checked:not(:focus) {
-      border: 2px solid var(--primary-foreground, #F9F9FB);
+      border: 2px solid var(--primary-foreground-color, #F9F9FB);
     }
 
     &:focus:checked:after {
@@ -34,7 +34,7 @@
       position: absolute;
       font-size: var(--paragraph-small);
       line-height: var(--paragraph-small);
-      color: var(--primary-foreground, #F9F9FB);
+      color: var(--primary-foreground-color, #F9F9FB);
     }
   }
 

--- a/component-library/components/generic/form/checkbox-input/checkbox-input.scss
+++ b/component-library/components/generic/form/checkbox-input/checkbox-input.scss
@@ -2,13 +2,13 @@
   display: flex;
   gap: 10px;
   align-items: center;
-  color: var(--brand-grey-000, #F9F9FB);
+  color: var(--primary-foreground, #F9F9FB);
 
   &__input {
     appearance: none;
     width: 16px;
     height: 16px;
-    border: 2px solid var(--brand-grey-000, #F9F9FB);
+    border: 2px solid var(--primary-foreground, #F9F9FB);
     cursor: pointer;
     position: relative;
     display: flex;
@@ -22,7 +22,7 @@
     }
 
     &:checked:not(:focus) {
-      border: 2px solid var(--brand-grey-000, #F9F9FB);
+      border: 2px solid var(--primary-foreground, #F9F9FB);
     }
 
     &:focus:checked:after {
@@ -34,7 +34,7 @@
       position: absolute;
       font-size: var(--paragraph-small);
       line-height: var(--paragraph-small);
-      color: var(--brand-grey-000, #F9F9FB);
+      color: var(--primary-foreground, #F9F9FB);
     }
   }
 

--- a/component-library/components/generic/form/country-select-input/country-select-input.eleventy.liquid
+++ b/component-library/components/generic/form/country-select-input/country-select-input.eleventy.liquid
@@ -244,7 +244,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/country-select-input/country-select-input.eleventy.liquid
+++ b/component-library/components/generic/form/country-select-input/country-select-input.eleventy.liquid
@@ -244,7 +244,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/country-select-input/country-select-input.scss
+++ b/component-library/components/generic/form/country-select-input/country-select-input.scss
@@ -1,7 +1,7 @@
 .c-country-select-input {
     display: grid;
     gap: 4px;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__label {
         font-size: var(--label);
@@ -21,7 +21,7 @@
         -webkit-appearance: none;
         appearance: none;
         background-color: transparent;
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
 
         &::placeholder {
             opacity: 1;
@@ -48,6 +48,6 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
 }

--- a/component-library/components/generic/form/country-select-input/country-select-input.scss
+++ b/component-library/components/generic/form/country-select-input/country-select-input.scss
@@ -1,7 +1,7 @@
 .c-country-select-input {
     display: grid;
     gap: 4px;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -21,7 +21,7 @@
         -webkit-appearance: none;
         appearance: none;
         background-color: transparent;
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -48,6 +48,6 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
 }

--- a/component-library/components/generic/form/country-select-input/country-select-input.scss
+++ b/component-library/components/generic/form/country-select-input/country-select-input.scss
@@ -1,7 +1,7 @@
 .c-country-select-input {
     display: grid;
     gap: 4px;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -21,7 +21,7 @@
         -webkit-appearance: none;
         appearance: none;
         background-color: transparent;
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -48,6 +48,6 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
 }

--- a/component-library/components/generic/form/country-select-input/country-select-input.scss
+++ b/component-library/components/generic/form/country-select-input/country-select-input.scss
@@ -29,7 +29,7 @@
         }
 
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
     }

--- a/component-library/components/generic/form/date-input/date-input.eleventy.liquid
+++ b/component-library/components/generic/form/date-input/date-input.eleventy.liquid
@@ -22,7 +22,7 @@
     {% endif %}
 
     <div class="{{ c }}__error error">
-        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-red-300, #BF2323)' %}
+        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
         <p class="{{ c }}__error__text error__text" id="{{ id }}--error">Error Message<p>
     </div>
 </div>

--- a/component-library/components/generic/form/date-input/date-input.eleventy.liquid
+++ b/component-library/components/generic/form/date-input/date-input.eleventy.liquid
@@ -16,7 +16,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/date-input/date-input.eleventy.liquid
+++ b/component-library/components/generic/form/date-input/date-input.eleventy.liquid
@@ -16,7 +16,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/date-input/date-input.scss
+++ b/component-library/components/generic/form/date-input/date-input.scss
@@ -27,7 +27,7 @@
         }
 
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
 
@@ -79,7 +79,7 @@
 
     &__error {
         display: none;
-        color: var(--error-red-300, #BF2323);
+        color: var(--error-color, #BF2323);
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);

--- a/component-library/components/generic/form/date-input/date-input.scss
+++ b/component-library/components/generic/form/date-input/date-input.scss
@@ -1,7 +1,7 @@
 .c-date-input {
     display: grid;
     gap: 4px;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__label {
         font-size: var(--label);
@@ -19,7 +19,7 @@
         border: 2px solid;
         position: relative;
         background-color: transparent;
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
         
         &::placeholder {
             opacity: 1;
@@ -50,7 +50,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
 
     &__icon, &__input, &__dropdown-arrow {

--- a/component-library/components/generic/form/date-input/date-input.scss
+++ b/component-library/components/generic/form/date-input/date-input.scss
@@ -1,7 +1,7 @@
 .c-date-input {
     display: grid;
     gap: 4px;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -19,7 +19,7 @@
         border: 2px solid;
         position: relative;
         background-color: transparent;
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
         
         &::placeholder {
             opacity: 1;
@@ -50,7 +50,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
 
     &__icon, &__input, &__dropdown-arrow {

--- a/component-library/components/generic/form/date-input/date-input.scss
+++ b/component-library/components/generic/form/date-input/date-input.scss
@@ -1,7 +1,7 @@
 .c-date-input {
     display: grid;
     gap: 4px;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -19,7 +19,7 @@
         border: 2px solid;
         position: relative;
         background-color: transparent;
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
         
         &::placeholder {
             opacity: 1;
@@ -50,7 +50,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
 
     &__icon, &__input, &__dropdown-arrow {

--- a/component-library/components/generic/form/email-input/email-input.eleventy.liquid
+++ b/component-library/components/generic/form/email-input/email-input.eleventy.liquid
@@ -13,7 +13,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/email-input/email-input.eleventy.liquid
+++ b/component-library/components/generic/form/email-input/email-input.eleventy.liquid
@@ -13,7 +13,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/email-input/email-input.eleventy.liquid
+++ b/component-library/components/generic/form/email-input/email-input.eleventy.liquid
@@ -19,7 +19,7 @@
     {% endif %}
 
     <div class="{{ c }}__error error">
-        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-red-300, #BF2323)' %}
+        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
         <p class="{{ c }}__error__text error__text" id="{{ id }}--error">Error Message<p>
     </div>
 </div>

--- a/component-library/components/generic/form/email-input/email-input.scss
+++ b/component-library/components/generic/form/email-input/email-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/email-input/email-input.scss
+++ b/component-library/components/generic/form/email-input/email-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
         
     &__error {

--- a/component-library/components/generic/form/email-input/email-input.scss
+++ b/component-library/components/generic/form/email-input/email-input.scss
@@ -22,7 +22,7 @@
         }
 
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
     }
@@ -37,7 +37,7 @@
         
     &__error {
         display: none;
-        color: var(--error-red-300, #BF2323);
+        color: var(--error-color, #BF2323);
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);

--- a/component-library/components/generic/form/email-input/email-input.scss
+++ b/component-library/components/generic/form/email-input/email-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/phone-input/phone-input.eleventy.liquid
+++ b/component-library/components/generic/form/phone-input/phone-input.eleventy.liquid
@@ -13,7 +13,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/phone-input/phone-input.eleventy.liquid
+++ b/component-library/components/generic/form/phone-input/phone-input.eleventy.liquid
@@ -13,7 +13,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/phone-input/phone-input.eleventy.liquid
+++ b/component-library/components/generic/form/phone-input/phone-input.eleventy.liquid
@@ -19,7 +19,7 @@
     {% endif %}
 
     <div class="{{ c }}__error error">
-        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-red-300, #BF2323)' %}
+        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
         <p class="{{ c }}__error__text error__text" id="{{ id }}--error">Error Message<p>
     </div>
 </div>

--- a/component-library/components/generic/form/phone-input/phone-input.scss
+++ b/component-library/components/generic/form/phone-input/phone-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/phone-input/phone-input.scss
+++ b/component-library/components/generic/form/phone-input/phone-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
         
     &__error {

--- a/component-library/components/generic/form/phone-input/phone-input.scss
+++ b/component-library/components/generic/form/phone-input/phone-input.scss
@@ -22,7 +22,7 @@
         }
 
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
     }
@@ -37,7 +37,7 @@
         
     &__error {
         display: none;
-        color: var(--error-red-300, #BF2323);
+        color: var(--error-color, #BF2323);
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);

--- a/component-library/components/generic/form/phone-input/phone-input.scss
+++ b/component-library/components/generic/form/phone-input/phone-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/radio-button-group/radio-button-group.eleventy.liquid
+++ b/component-library/components/generic/form/radio-button-group/radio-button-group.eleventy.liquid
@@ -13,7 +13,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/radio-button-group/radio-button-group.eleventy.liquid
+++ b/component-library/components/generic/form/radio-button-group/radio-button-group.eleventy.liquid
@@ -19,7 +19,7 @@
     {% endif %}
 
     <div class="{{ c }}__error error">
-        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-red-300, #BF2323)' %}
+        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
         <p class="{{ c }}__error__text error__text" id="{{ id }}--error">Error Message<p>
     </div>
 

--- a/component-library/components/generic/form/radio-button-group/radio-button-group.eleventy.liquid
+++ b/component-library/components/generic/form/radio-button-group/radio-button-group.eleventy.liquid
@@ -13,7 +13,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/radio-button-group/radio-button-group.scss
+++ b/component-library/components/generic/form/radio-button-group/radio-button-group.scss
@@ -34,7 +34,7 @@
         
     &__error {
         display: none;
-        color: var(--error-red-300, #BF2323);
+        color: var(--error-color, #BF2323);
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);

--- a/component-library/components/generic/form/radio-button-group/radio-button-group.scss
+++ b/component-library/components/generic/form/radio-button-group/radio-button-group.scss
@@ -1,5 +1,5 @@
 .c-radio-button-group {
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -29,7 +29,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/radio-button-group/radio-button-group.scss
+++ b/component-library/components/generic/form/radio-button-group/radio-button-group.scss
@@ -1,5 +1,5 @@
 .c-radio-button-group {
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -29,7 +29,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
         
     &__error {

--- a/component-library/components/generic/form/radio-button-group/radio-button-group.scss
+++ b/component-library/components/generic/form/radio-button-group/radio-button-group.scss
@@ -1,5 +1,5 @@
 .c-radio-button-group {
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -29,7 +29,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/radio-input/radio-input.scss
+++ b/component-library/components/generic/form/radio-input/radio-input.scss
@@ -2,13 +2,13 @@
     display: flex;
     gap: 10px;
     align-items: center;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__input {
         appearance: none;
         width: 16px;
         height: 16px;
-        border: 2px solid var(--brand-grey-000, #F9F9FB);
+        border: 2px solid var(--primary-foreground, #F9F9FB);
         border-radius: 50%;
         cursor: pointer;
         display: flex;
@@ -25,7 +25,7 @@
         }
     
         &:checked:not(:focus) {
-          border: 2px solid var(--brand-grey-000, #F9F9FB);
+          border: 2px solid var(--primary-foreground, #F9F9FB);
         }
     
         &:checked:after {
@@ -33,7 +33,7 @@
           width: 8px;
           height: 8px;
           border-radius: 50%;
-          background: var(--brand-grey-000, #F9F9FB);
+          background: var(--primary-foreground, #F9F9FB);
         }
     }
 

--- a/component-library/components/generic/form/radio-input/radio-input.scss
+++ b/component-library/components/generic/form/radio-input/radio-input.scss
@@ -2,13 +2,13 @@
     display: flex;
     gap: 10px;
     align-items: center;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__input {
         appearance: none;
         width: 16px;
         height: 16px;
-        border: 2px solid var(--primary-foreground-color, #F9F9FB);
+        border: 2px solid var(--main-text-color);
         border-radius: 50%;
         cursor: pointer;
         display: flex;
@@ -25,7 +25,7 @@
         }
     
         &:checked:not(:focus) {
-          border: 2px solid var(--primary-foreground-color, #F9F9FB);
+          border: 2px solid var(--main-text-color);
         }
     
         &:checked:after {
@@ -33,7 +33,7 @@
           width: 8px;
           height: 8px;
           border-radius: 50%;
-          background: var(--primary-foreground-color, #F9F9FB);
+          background: var(--main-text-color);
         }
     }
 

--- a/component-library/components/generic/form/radio-input/radio-input.scss
+++ b/component-library/components/generic/form/radio-input/radio-input.scss
@@ -16,12 +16,12 @@
         align-items: center;
     
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
 
         &:focus:checked:after {
-            background-color: var(--interaction-blue-300, #2566F2);
+            background-color: var(--interaction-color, #2566F2);
         }
     
         &:checked:not(:focus) {

--- a/component-library/components/generic/form/radio-input/radio-input.scss
+++ b/component-library/components/generic/form/radio-input/radio-input.scss
@@ -2,13 +2,13 @@
     display: flex;
     gap: 10px;
     align-items: center;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__input {
         appearance: none;
         width: 16px;
         height: 16px;
-        border: 2px solid var(--primary-foreground, #F9F9FB);
+        border: 2px solid var(--primary-foreground-color, #F9F9FB);
         border-radius: 50%;
         cursor: pointer;
         display: flex;
@@ -25,7 +25,7 @@
         }
     
         &:checked:not(:focus) {
-          border: 2px solid var(--primary-foreground, #F9F9FB);
+          border: 2px solid var(--primary-foreground-color, #F9F9FB);
         }
     
         &:checked:after {
@@ -33,7 +33,7 @@
           width: 8px;
           height: 8px;
           border-radius: 50%;
-          background: var(--primary-foreground, #F9F9FB);
+          background: var(--primary-foreground-color, #F9F9FB);
         }
     }
 

--- a/component-library/components/generic/form/select-input/select-input.eleventy.liquid
+++ b/component-library/components/generic/form/select-input/select-input.eleventy.liquid
@@ -13,7 +13,7 @@
 
   {% if helper_text %}
       <div class="{{ c }}__helper">
-          {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+          {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
           <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
       </div>
   {% endif %}

--- a/component-library/components/generic/form/select-input/select-input.eleventy.liquid
+++ b/component-library/components/generic/form/select-input/select-input.eleventy.liquid
@@ -13,7 +13,7 @@
 
   {% if helper_text %}
       <div class="{{ c }}__helper">
-          {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+          {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
           <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
       </div>
   {% endif %}

--- a/component-library/components/generic/form/select-input/select-input.scss
+++ b/component-library/components/generic/form/select-input/select-input.scss
@@ -1,7 +1,7 @@
 .c-select-input {
     display: grid;
     gap: 4px;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -20,7 +20,7 @@
         appearance: none;
 
         background-color: transparent;
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
 
         &:focus {
             border: 2px solid var(--interaction-blue-300, #2566F2);
@@ -42,6 +42,6 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
 }

--- a/component-library/components/generic/form/select-input/select-input.scss
+++ b/component-library/components/generic/form/select-input/select-input.scss
@@ -1,7 +1,7 @@
 .c-select-input {
     display: grid;
     gap: 4px;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -20,7 +20,7 @@
         appearance: none;
 
         background-color: transparent;
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
 
         &:focus {
             border: 2px solid var(--interaction-color, #2566F2);
@@ -42,6 +42,6 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
 }

--- a/component-library/components/generic/form/select-input/select-input.scss
+++ b/component-library/components/generic/form/select-input/select-input.scss
@@ -23,7 +23,7 @@
         color: var(--primary-foreground, #F9F9FB);
 
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
     }

--- a/component-library/components/generic/form/select-input/select-input.scss
+++ b/component-library/components/generic/form/select-input/select-input.scss
@@ -1,7 +1,7 @@
 .c-select-input {
     display: grid;
     gap: 4px;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__label {
         font-size: var(--label);
@@ -20,7 +20,7 @@
         appearance: none;
 
         background-color: transparent;
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
 
         &:focus {
             border: 2px solid var(--interaction-color, #2566F2);
@@ -42,6 +42,6 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
 }

--- a/component-library/components/generic/form/text-area-input/text-area-input.eleventy.liquid
+++ b/component-library/components/generic/form/text-area-input/text-area-input.eleventy.liquid
@@ -13,7 +13,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/text-area-input/text-area-input.eleventy.liquid
+++ b/component-library/components/generic/form/text-area-input/text-area-input.eleventy.liquid
@@ -19,7 +19,7 @@
     {% endif %}
 
     <div class="{{ c }}__error error">
-        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-red-300, #BF2323)' %}
+        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
         <p class="{{ c }}__error__text error__text" id="{{ id }}--error">Error Message<p>
     </div>
 

--- a/component-library/components/generic/form/text-area-input/text-area-input.eleventy.liquid
+++ b/component-library/components/generic/form/text-area-input/text-area-input.eleventy.liquid
@@ -13,7 +13,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/text-area-input/text-area-input.scss
+++ b/component-library/components/generic/form/text-area-input/text-area-input.scss
@@ -24,7 +24,7 @@
         }
 
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
     }
@@ -39,7 +39,7 @@
         
     &__error {
         display: none;
-        color: var(--error-red-300, #BF2323);
+        color: var(--error-color, #BF2323);
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);

--- a/component-library/components/generic/form/text-area-input/text-area-input.scss
+++ b/component-library/components/generic/form/text-area-input/text-area-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__label {
         font-size: var(--label);
@@ -16,7 +16,7 @@
         width: 100%;
         resize: vertical;
         background-color: transparent;
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
 
         &::placeholder {
             opacity: 1;
@@ -34,7 +34,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
         
     &__error {

--- a/component-library/components/generic/form/text-area-input/text-area-input.scss
+++ b/component-library/components/generic/form/text-area-input/text-area-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -16,7 +16,7 @@
         width: 100%;
         resize: vertical;
         background-color: transparent;
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -34,7 +34,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/text-area-input/text-area-input.scss
+++ b/component-library/components/generic/form/text-area-input/text-area-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -16,7 +16,7 @@
         width: 100%;
         resize: vertical;
         background-color: transparent;
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -34,7 +34,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
         
     &__error {

--- a/component-library/components/generic/form/text-input/text-input.eleventy.liquid
+++ b/component-library/components/generic/form/text-input/text-input.eleventy.liquid
@@ -18,7 +18,7 @@
     {% endif %}
 
     <div class="{{ c }}__error error">
-        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-red-300, #BF2323)' %}
+        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
         <p class="{{ c }}__error__text error__text" id="{{ id }}--error">Error Message<p>
     </div>
 </div>

--- a/component-library/components/generic/form/text-input/text-input.eleventy.liquid
+++ b/component-library/components/generic/form/text-input/text-input.eleventy.liquid
@@ -12,7 +12,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/text-input/text-input.eleventy.liquid
+++ b/component-library/components/generic/form/text-input/text-input.eleventy.liquid
@@ -12,7 +12,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/text-input/text-input.scss
+++ b/component-library/components/generic/form/text-input/text-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
 
     &__error {

--- a/component-library/components/generic/form/text-input/text-input.scss
+++ b/component-library/components/generic/form/text-input/text-input.scss
@@ -22,7 +22,7 @@
         }
 
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
     }
@@ -37,7 +37,7 @@
 
     &__error {
         display: none;
-        color: var(--error-red-300, #BF2323);
+        color: var(--error-color, #BF2323);
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);

--- a/component-library/components/generic/form/text-input/text-input.scss
+++ b/component-library/components/generic/form/text-input/text-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
 
     &__error {

--- a/component-library/components/generic/form/text-input/text-input.scss
+++ b/component-library/components/generic/form/text-input/text-input.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__label {
         font-size: var(--label);
@@ -14,7 +14,7 @@
         border-radius: 4px;
         border: 2px solid;
         background-color: transparent;
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
 
         &::placeholder {
             opacity: 1;
@@ -32,7 +32,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
 
     &__error {

--- a/component-library/components/generic/form/time-input/time-input.eleventy.liquid
+++ b/component-library/components/generic/form/time-input/time-input.eleventy.liquid
@@ -15,7 +15,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--brand-grey-000, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/time-input/time-input.eleventy.liquid
+++ b/component-library/components/generic/form/time-input/time-input.eleventy.liquid
@@ -21,7 +21,7 @@
     {% endif %}
 
     <div class="{{ c }}__error error">
-        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-red-300, #BF2323)' %}
+        {% bookshop "generic/icon" hero_icon_name:"x-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--error-color, #BF2323)' %}
         <p class="{{ c }}__error__text error__text" id="{{ id }}--error">Error Message<p>
     </div>
 </div>

--- a/component-library/components/generic/form/time-input/time-input.eleventy.liquid
+++ b/component-library/components/generic/form/time-input/time-input.eleventy.liquid
@@ -15,7 +15,7 @@
 
     {% if helper_text %}
         <div class="{{ c }}__helper">
-            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground, #F9F9FB)' %}
+            {% bookshop "generic/icon" hero_icon_name:"information-circle" icon_type:"outline" icon_size:'extra-small' rounded_border:false color:'var(--primary-foreground-color, #F9F9FB)' %}
             <p class="{{ c }}__helper__text" id="{{ id }}--helper" role="tooltip">{{ helper_text }}<p>
         </div>
     {% endif %}

--- a/component-library/components/generic/form/time-input/time-input.scss
+++ b/component-library/components/generic/form/time-input/time-input.scss
@@ -22,7 +22,7 @@
         }
 
         &:focus {
-            border: 2px solid var(--interaction-blue-300, #2566F2);
+            border: 2px solid var(--interaction-color, #2566F2);
             outline: none;
         }
 
@@ -68,7 +68,7 @@
     
     &__error {
         display: none;
-        color: var(--error-red-300, #BF2323);
+        color: var(--error-color, #BF2323);
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);

--- a/component-library/components/generic/form/time-input/time-input.scss
+++ b/component-library/components/generic/form/time-input/time-input.scss
@@ -1,7 +1,7 @@
 .c-time-input {
     display: grid;
     gap: 4px;
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -13,7 +13,7 @@
         border-radius: 4px;
         border: 2px solid;
         position: relative;
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
         background-color: transparent;
 
         &::placeholder {
@@ -63,7 +63,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground, #F9F9FB);
+        color: var(--primary-foreground-color, #F9F9FB);
     }
     
     &__error {

--- a/component-library/components/generic/form/time-input/time-input.scss
+++ b/component-library/components/generic/form/time-input/time-input.scss
@@ -1,7 +1,7 @@
 .c-time-input {
     display: grid;
     gap: 4px;
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
 
     &__label {
         font-size: var(--label);
@@ -13,7 +13,7 @@
         border-radius: 4px;
         border: 2px solid;
         position: relative;
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
         background-color: transparent;
 
         &::placeholder {
@@ -63,7 +63,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--brand-grey-000, #F9F9FB);
+        color: var(--primary-foreground, #F9F9FB);
     }
     
     &__error {

--- a/component-library/components/generic/form/time-input/time-input.scss
+++ b/component-library/components/generic/form/time-input/time-input.scss
@@ -1,7 +1,7 @@
 .c-time-input {
     display: grid;
     gap: 4px;
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
 
     &__label {
         font-size: var(--label);
@@ -13,7 +13,7 @@
         border-radius: 4px;
         border: 2px solid;
         position: relative;
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
         background-color: transparent;
 
         &::placeholder {
@@ -63,7 +63,7 @@
         gap: 8px;
         font-size: var(--paragraph-small);
         line-height: var(--line-height);
-        color: var(--primary-foreground-color, #F9F9FB);
+        color: var(--main-text-color);
     }
     
     &__error {

--- a/component-library/components/generic/sample/sample.bookshop.yml
+++ b/component-library/components/generic/sample/sample.bookshop.yml
@@ -11,7 +11,7 @@ spec:
 blueprint:
   text: 
   styles:
-    background_variant: "Light"
+    background_variant: "primary"
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:

--- a/component-library/components/generic/sample/sample.eleventy.liquid
+++ b/component-library/components/generic/sample/sample.eleventy.liquid
@@ -2,6 +2,6 @@
 <div class="{{c}} 
             component 
             {% if styles.background_variant == "Dark" %} 
-                component--dark
+                component--secondary
             {% endif %}"><p>{{ text }}</p>
 </div>

--- a/component-library/components/generic/sample/sample.eleventy.liquid
+++ b/component-library/components/generic/sample/sample.eleventy.liquid
@@ -1,7 +1,7 @@
 {% assign c = "c-COMPONENTNAME" %}
 <div class="{{c}} 
             component 
-            {% if styles.background_variant == "Dark" %} 
+            {% if styles.background_variant == "secondary" %} 
                 component--secondary
             {% endif %}"><p>{{ text }}</p>
 </div>

--- a/component-library/components/generic/social-icons/social-icons.scss
+++ b/component-library/components/generic/social-icons/social-icons.scss
@@ -5,9 +5,9 @@
   align-items: center;
   gap: 1rem;
 
-  --dynamic-fill-color: var(--fill-color, var(--brand-grey-000));
-  --dynamic-hover-color: var(--hover-color, var(--brand-grey-000));
-  --dynamic-fill-color-hover: var(--fill-color-hover, var(--brand-grey-900));
+  --dynamic-fill-color: var(--fill-color, var(--primary-foreground));
+  --dynamic-hover-color: var(--hover-color, var(--primary-foreground));
+  --dynamic-fill-color-hover: var(--fill-color-hover, var(--secondary-background));
 
   &__icon {
     transition: background-color 300ms ease-out, fill 300ms ease-out;

--- a/component-library/components/generic/social-icons/social-icons.scss
+++ b/component-library/components/generic/social-icons/social-icons.scss
@@ -5,9 +5,9 @@
   align-items: center;
   gap: 1rem;
 
-  --dynamic-fill-color: var(--fill-color, var(--primary-foreground));
-  --dynamic-hover-color: var(--hover-color, var(--primary-foreground));
-  --dynamic-fill-color-hover: var(--fill-color-hover, var(--secondary-background));
+  --dynamic-fill-color: var(--fill-color, var(--primary-foreground-color));
+  --dynamic-hover-color: var(--hover-color, var(--primary-foreground-color));
+  --dynamic-fill-color-hover: var(--fill-color-hover, var(--secondary-background-color));
 
   &__icon {
     transition: background-color 300ms ease-out, fill 300ms ease-out;

--- a/component-library/components/generic/social-icons/social-icons.scss
+++ b/component-library/components/generic/social-icons/social-icons.scss
@@ -5,9 +5,9 @@
   align-items: center;
   gap: 1rem;
 
-  --dynamic-fill-color: var(--fill-color, var(--primary-foreground-color));
-  --dynamic-hover-color: var(--hover-color, var(--primary-foreground-color));
-  --dynamic-fill-color-hover: var(--fill-color-hover, var(--secondary-background-color));
+  --dynamic-fill-color: var(--fill-color, var(--main-text-color));
+  --dynamic-hover-color: var(--hover-color, var(--main-text-color));
+  --dynamic-fill-color-hover: var(--fill-color-hover, var(--alt-background-color));
 
   &__icon {
     transition: background-color 300ms ease-out, fill 300ms ease-out;

--- a/component-library/components/sections/centered-large-asset/centered-large-asset.bookshop.yml
+++ b/component-library/components/sections/centered-large-asset/centered-large-asset.bookshop.yml
@@ -15,7 +15,7 @@ blueprint:
     asset: bookshop:structure:asset_blocks
     button: bookshop:generic/button
   styles:
-    background_variant: light
+    background_variant: primary
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:
@@ -28,7 +28,7 @@ preview:
         Whether your business is a restaurant, a barber shop, a gym, or a café, our small business template has you covered. Add your services to the list below, as many as you like, and let people contact you or book now.
     button: bookshop:generic/button
   styles:
-    background_variant: light
+    background_variant: primary
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:

--- a/component-library/components/sections/centered-large-asset/centered-large-asset.eleventy.liquid
+++ b/component-library/components/sections/centered-large-asset/centered-large-asset.eleventy.liquid
@@ -1,7 +1,7 @@
 {% assign_local c = "c-centered-large-asset" %}
 <section class="{{ c }} component 
             {% if styles.background_variant == 'dark' %} 
-                component--dark
+                component--secondary
             {% endif %}">
     
     {% if content.heading or content.description %}

--- a/component-library/components/sections/centered-large-asset/centered-large-asset.eleventy.liquid
+++ b/component-library/components/sections/centered-large-asset/centered-large-asset.eleventy.liquid
@@ -1,6 +1,6 @@
 {% assign_local c = "c-centered-large-asset" %}
 <section class="{{ c }} component 
-            {% if styles.background_variant == 'dark' %} 
+            {% if styles.background_variant == 'secondary' %} 
                 component--secondary
             {% endif %}">
     

--- a/component-library/components/sections/centered-large-asset/centered-large-asset.scss
+++ b/component-library/components/sections/centered-large-asset/centered-large-asset.scss
@@ -1,5 +1,5 @@
 .c-centered-large-asset {
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;

--- a/component-library/components/sections/centered-large-asset/centered-large-asset.scss
+++ b/component-library/components/sections/centered-large-asset/centered-large-asset.scss
@@ -1,5 +1,5 @@
 .c-centered-large-asset {
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;

--- a/component-library/components/sections/centered-large-asset/centered-large-asset.scss
+++ b/component-library/components/sections/centered-large-asset/centered-large-asset.scss
@@ -1,5 +1,5 @@
 .c-centered-large-asset {
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;

--- a/component-library/components/sections/embed/embed.bookshop.yml
+++ b/component-library/components/sections/embed/embed.bookshop.yml
@@ -16,7 +16,7 @@ blueprint:
     button: bookshop:generic/button
     show_note: true
   styles:
-    background_variant: light
+    background_variant: primary
     content_alignment: center
 
 # Overrides any fields in the blueprint when viewing this component in the component browser

--- a/component-library/components/sections/embed/embed.eleventy.liquid
+++ b/component-library/components/sections/embed/embed.eleventy.liquid
@@ -1,7 +1,7 @@
 {% assign_local c = "c-embed" %}
 <section class="{{ c }} {{ c }}--content-align-{{ styles.content_alignment }} component 
-            {% if styles.background_variant == 'dark' %} 
-                component--dark
+            {% if styles.background_variant == 'secondary' %} 
+                component--secondary
             {% endif %}" >
 
     {% if content.heading or content.description %}

--- a/component-library/components/sections/embed/embed.scss
+++ b/component-library/components/sections/embed/embed.scss
@@ -1,5 +1,5 @@
 .c-embed {
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--main-text-color);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;

--- a/component-library/components/sections/form/form.bookshop.yml
+++ b/component-library/components/sections/form/form.bookshop.yml
@@ -14,7 +14,7 @@ blueprint:
     description: Description text to compliment the block
     form: bookshop:simple/form-builder
   styles:
-    background_variant: light
+    background_variant: primary
     content_alignment: center
 
 # Overrides any fields in the blueprint when viewing this component in the component browser

--- a/component-library/components/sections/form/form.eleventy.liquid
+++ b/component-library/components/sections/form/form.eleventy.liquid
@@ -1,7 +1,7 @@
 {% assign_local c = "c-form" %}
 <section class="{{ c }} {{ c }}--content-align-{{ styles.content_alignment }} component 
             {% if styles.background_variant == 'dark' %} 
-                component--dark
+                component--secondary
             {% endif %}" >
 
     <div class="{{ c }}__heading">

--- a/component-library/components/sections/form/form.eleventy.liquid
+++ b/component-library/components/sections/form/form.eleventy.liquid
@@ -1,6 +1,6 @@
 {% assign_local c = "c-form" %}
 <section class="{{ c }} {{ c }}--content-align-{{ styles.content_alignment }} component 
-            {% if styles.background_variant == 'dark' %} 
+            {% if styles.background_variant == 'secondary' %} 
                 component--secondary
             {% endif %}" >
 

--- a/component-library/components/sections/form/form.scss
+++ b/component-library/components/sections/form/form.scss
@@ -1,5 +1,5 @@
 .c-form {
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;

--- a/component-library/components/sections/form/form.scss
+++ b/component-library/components/sections/form/form.scss
@@ -1,5 +1,5 @@
 .c-form {
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;

--- a/component-library/components/sections/form/form.scss
+++ b/component-library/components/sections/form/form.scss
@@ -1,5 +1,5 @@
 .c-form {
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;

--- a/component-library/components/sections/grid--gallery-images/grid--gallery-images.bookshop.yml
+++ b/component-library/components/sections/grid--gallery-images/grid--gallery-images.bookshop.yml
@@ -14,7 +14,7 @@ blueprint:
     description: Description text to compliment the block
     gallery: bookshop:simple/gallery!
   styles:
-    background_variant: light
+    background_variant: primary
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:

--- a/component-library/components/sections/grid--gallery-images/grid--gallery-images.bookshop.yml
+++ b/component-library/components/sections/grid--gallery-images/grid--gallery-images.bookshop.yml
@@ -29,7 +29,7 @@ preview:
       below, as many as you like, and let people contact you or book now.
     gallery: bookshop:simple/gallery
   styles:
-    background_variant: light
+    background_variant: primary
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:

--- a/component-library/components/sections/grid--gallery-images/grid--gallery-images.eleventy.liquid
+++ b/component-library/components/sections/grid--gallery-images/grid--gallery-images.eleventy.liquid
@@ -1,7 +1,7 @@
 {% assign_local c = "c-grid--gallery-images" %}
 <section class="{{ c }} component 
-            {% if styles.background_variant == 'dark' %} 
-                component--dark
+            {% if styles.background_variant == 'secondary' %} 
+                component--secondary
             {% endif %}">
     
     {% if content.heading or content.description %}

--- a/component-library/components/sections/grid--gallery-images/grid--gallery-images.scss
+++ b/component-library/components/sections/grid--gallery-images/grid--gallery-images.scss
@@ -1,5 +1,5 @@
 .c-grid--gallery-images {
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--main-text-color);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -16,14 +16,14 @@ blueprint:
     image: bookshop:generic/image!
   styles:
     image_alignment: left
-    background_variant: light
+    background_variant: primary
 
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:
   styles:
     image_alignment: left
-    background_variant: light
+    background_variant: primary
   content:
     heading:
       _bookshop_name: generic/component-heading

--- a/component-library/components/sections/hero/hero.eleventy.liquid
+++ b/component-library/components/sections/hero/hero.eleventy.liquid
@@ -1,7 +1,7 @@
 {% assign_local c = "c-hero" %}
 <section class="{{ c }} {% if styles.image_alignment =='left' %}{{ c }}--left-right-variant {{ c }}--image-left{% elsif styles.image_alignment =='right' %}{{ c }}--left-right-variant {{ c }}--image-right{% endif %} component component--full-height
             {% if styles.background_variant == 'dark' %} 
-                component--dark
+                component--secondary
             {% endif %}">
     {% bookshop "generic/image" bind:content.image %}
     <div class="{{ c }}__cover"></div>

--- a/component-library/components/sections/hero/hero.eleventy.liquid
+++ b/component-library/components/sections/hero/hero.eleventy.liquid
@@ -1,6 +1,6 @@
 {% assign_local c = "c-hero" %}
 <section class="{{ c }} {% if styles.image_alignment =='left' %}{{ c }}--left-right-variant {{ c }}--image-left{% elsif styles.image_alignment =='right' %}{{ c }}--left-right-variant {{ c }}--image-right{% endif %} component component--full-height
-            {% if styles.background_variant == 'dark' %} 
+            {% if styles.background_variant == 'secondary' %} 
                 component--secondary
             {% endif %}">
     {% bookshop "generic/image" bind:content.image %}

--- a/component-library/components/sections/hero/hero.scss
+++ b/component-library/components/sections/hero/hero.scss
@@ -4,9 +4,9 @@
   display: grid;
   grid-template-columns: var(--twelve-column-grid);
   grid-template-rows: minmax(0, 1fr);
-  color: var(--primary-foreground, #f9f9fb);
+  color: var(--primary-foreground-color, #f9f9fb);
   &__cover {
-    background-color: var(secondary-background-color, rgba(27, 27, 29, 1));
+    background-color: var(secondary-background-color-color, rgba(27, 27, 29, 1));
     grid-row: 1 / -1;
     grid-column: 1 / -1;
   }

--- a/component-library/components/sections/hero/hero.scss
+++ b/component-library/components/sections/hero/hero.scss
@@ -22,6 +22,7 @@
     object-position: 50% 50%;
   }
   &__content {
+    z-index:1;
     display: grid;
     gap: 1.5rem;
     grid-row: 1 / -1;

--- a/component-library/components/sections/hero/hero.scss
+++ b/component-library/components/sections/hero/hero.scss
@@ -4,9 +4,9 @@
   display: grid;
   grid-template-columns: var(--twelve-column-grid);
   grid-template-rows: minmax(0, 1fr);
-  color: var(--primary-foreground-color, #f9f9fb);
+  color: var(--main-text-color);
   &__cover {
-    background-color: var(secondary-background-color-color, rgba(27, 27, 29, 1));
+    background-color: var(--alt-background-color, #1b1b1d); // supposed to be the alt, or always a 'dark' color??
     grid-row: 1 / -1;
     grid-column: 1 / -1;
   }

--- a/component-library/components/sections/hero/hero.scss
+++ b/component-library/components/sections/hero/hero.scss
@@ -6,7 +6,8 @@
   grid-template-rows: minmax(0, 1fr);
   color: var(--main-text-color);
   &__cover {
-    background-color: var(--alt-background-color, #1b1b1d); // supposed to be the alt, or always a 'dark' color??
+    background-color: var(--main-background-color);
+    opacity:.4;
     grid-row: 1 / -1;
     grid-column: 1 / -1;
   }

--- a/component-library/components/sections/hero/hero.scss
+++ b/component-library/components/sections/hero/hero.scss
@@ -4,9 +4,9 @@
   display: grid;
   grid-template-columns: var(--twelve-column-grid);
   grid-template-rows: minmax(0, 1fr);
-  color: var(--brand-grey-000, #f9f9fb);
+  color: var(--primary-foreground, #f9f9fb);
   &__cover {
-    background-color: var(--header-color, rgba(27, 27, 29, 1));
+    background-color: var(secondary-background-color, rgba(27, 27, 29, 1));
     grid-row: 1 / -1;
     grid-column: 1 / -1;
   }

--- a/component-library/components/sections/price-list/price-list.bookshop.yml
+++ b/component-library/components/sections/price-list/price-list.bookshop.yml
@@ -19,7 +19,7 @@ blueprint:
             detail: $$
     # TODO: add button(s) subcomponent
   styles:
-    background_variant: light
+    background_variant: primary
     content_alignment: center
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
@@ -51,7 +51,7 @@ preview:
           - label: Service 3
             detail: $40
   styles:
-    background_variant: light
+    background_variant: primary
     content_alignment: center
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint

--- a/component-library/components/sections/price-list/price-list.eleventy.liquid
+++ b/component-library/components/sections/price-list/price-list.eleventy.liquid
@@ -1,6 +1,6 @@
 {% assign pl = "c-price-list" %}
 <section class="{{ pl }} {{ pl }}--content-align-{{ styles.content_alignment }} component 
-            {% if styles.background_variant == 'dark' %} 
+            {% if styles.background_variant == 'secondary' %} 
                 component--secondary
             {% endif %}">
     

--- a/component-library/components/sections/price-list/price-list.eleventy.liquid
+++ b/component-library/components/sections/price-list/price-list.eleventy.liquid
@@ -1,7 +1,7 @@
 {% assign pl = "c-price-list" %}
 <section class="{{ pl }} {{ pl }}--content-align-{{ styles.content_alignment }} component 
             {% if styles.background_variant == 'dark' %} 
-                component--dark
+                component--secondary
             {% endif %}">
     
     <div class="{{ pl }}__heading">

--- a/component-library/components/sections/price-list/price-list.scss
+++ b/component-library/components/sections/price-list/price-list.scss
@@ -1,5 +1,5 @@
 .c-price-list {
-    color: var(--primary-foreground-color, #F9F9FB);
+    color: var(--main-text-color);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;
@@ -58,7 +58,7 @@
                 }
 
                 &__seperator {
-                    border-bottom: 1px var(--primary-foreground-color, #F9F9FB) dotted
+                    border-bottom: 1px var(--main-text-color) dotted
                 }
             }
         }

--- a/component-library/components/sections/price-list/price-list.scss
+++ b/component-library/components/sections/price-list/price-list.scss
@@ -1,5 +1,5 @@
 .c-price-list {
-    color: var(--primary-foreground, #F9F9FB);
+    color: var(--primary-foreground-color, #F9F9FB);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;
@@ -58,7 +58,7 @@
                 }
 
                 &__seperator {
-                    border-bottom: 1px var(--primary-foreground, #F9F9FB) dotted
+                    border-bottom: 1px var(--primary-foreground-color, #F9F9FB) dotted
                 }
             }
         }

--- a/component-library/components/sections/price-list/price-list.scss
+++ b/component-library/components/sections/price-list/price-list.scss
@@ -1,5 +1,5 @@
 .c-price-list {
-    color: var(--brand-grey-000, #F9F9FB);
+    color: var(--primary-foreground, #F9F9FB);
     display: grid;
     grid-template-columns: var(--twelve-column-grid);
     row-gap: 48px;
@@ -58,7 +58,7 @@
                 }
 
                 &__seperator {
-                    border-bottom: 1px var(--brand-grey-000, #F9F9FB) dotted
+                    border-bottom: 1px var(--primary-foreground, #F9F9FB) dotted
                 }
             }
         }

--- a/component-library/components/sections/simple-text-block/simple-text-block.bookshop.yml
+++ b/component-library/components/sections/simple-text-block/simple-text-block.bookshop.yml
@@ -13,7 +13,7 @@ blueprint:
     heading: bookshop:generic/component-heading!
     text: bookshop:generic/text-block!
   styles:
-    background_variant: light
+    background_variant: primary
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:

--- a/component-library/components/sections/simple-text-block/simple-text-block.eleventy.liquid
+++ b/component-library/components/sections/simple-text-block/simple-text-block.eleventy.liquid
@@ -2,8 +2,8 @@
 
 
 <section class='{{c}} component 
-{% if styles.background_variant == 'dark' %} 
-    component--dark
+{% if styles.background_variant == 'secondary' %} 
+    component--secondary
 {% endif %} '>
     <div class='{{c}}__content'>
         {% bookshop "generic/component-heading" bind:content.heading %}

--- a/component-library/components/sections/simple-text-block/simple-text-block.scss
+++ b/component-library/components/sections/simple-text-block/simple-text-block.scss
@@ -3,7 +3,6 @@
     grid-template-columns: var(--twelve-column-grid);
     justify-content: center;
     align-items: center;
-    color: var(--neutral-000, #FFF);
 
     &__content {
         grid-column: 2 / -2;

--- a/component-library/components/simple/card/card.bookshop.yml
+++ b/component-library/components/simple/card/card.bookshop.yml
@@ -17,7 +17,7 @@ blueprint:
       text: "Button text"
       open_in_new_tab: false
   styles:
-    background_variant: dark
+    background_variant: secondary
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:

--- a/component-library/components/simple/card/card.eleventy.liquid
+++ b/component-library/components/simple/card/card.eleventy.liquid
@@ -1,7 +1,7 @@
 {%  assign_local c = 'c-card' %}
 <div class="{{c}} component component--full-height
-            {% if styles.background_variant == 'dark' %} 
-                component--dark
+            {% if styles.background_variant == 'secondary' %} 
+                component--secondary
             {% endif %}
             {% if content.imagery._bookshop_name == 'generic/image' %} 
                 {{ c }}--image 

--- a/component-library/components/simple/card/card.scss
+++ b/component-library/components/simple/card/card.scss
@@ -1,7 +1,7 @@
 .c-card {
     display: flex;
     flex-direction: column;    
-    color:var(--brand-grey-000);    
+    color: var(--main-text-color);
     gap:1.5rem;    
 
     &--icon{

--- a/component-library/components/simple/form-builder/form-builder.scss
+++ b/component-library/components/simple/form-builder/form-builder.scss
@@ -11,4 +11,8 @@
     .c-icon__image, .c-icon__svg {
         --c-icon-color: var(--main-text-color);
     }
+
+    & .error .c-icon__svg {
+        --c-icon-color: var(--error-color);
+    }
 }

--- a/component-library/components/simple/form-builder/form-builder.scss
+++ b/component-library/components/simple/form-builder/form-builder.scss
@@ -7,4 +7,8 @@
     &__submit-button {
         text-align: center;
     }
+
+    .c-icon__image, .c-icon__svg {
+        --c-icon-color: var(--main-text-color);
+    }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "fetch-theme-colors": "node ./utils/fetch-theme-colors.js",
     "bookshop-sass:build": "bookshop-sass -b component-library -o css/bookshop.css",
     "bookshop-sass:watch": "bookshop-sass -b component-library -o css/bookshop.css -w",
     "bookshop:browser": "bookshop-browser",
@@ -13,7 +14,7 @@
     "eleventy:watch": "ELEVENTY_ENV=development eleventy --serve",
     "sass:watch": "sass --no-source-map --watch src/assets/styles:css",
     "sass:build": "sass --no-source-map src/assets/styles:css",
-    "start": "npm-run-all sass:build bookshop-sass:build --parallel bookshop-sass:watch sass:watch bookshop:browser eleventy:watch"
+    "start": "npm-run-all fetch-theme-colors sass:build bookshop-sass:build --parallel bookshop-sass:watch sass:watch bookshop:browser eleventy:watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eleventy:watch": "ELEVENTY_ENV=development eleventy --serve",
     "sass:watch": "sass --no-source-map --watch src/assets/styles:css",
     "sass:build": "sass --no-source-map src/assets/styles:css",
-    "start": "npm-run-all sass:build bookshop-sass:build --parallel bookshop-sass:watch sass:watch bookshop:browser eleventy:watch"
+    "start": "npm-run-all bookshop-sass:build --parallel bookshop-sass:watch sass:watch bookshop:browser eleventy:watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eleventy:watch": "ELEVENTY_ENV=development eleventy --serve",
     "sass:watch": "sass --no-source-map --watch src/assets/styles:css",
     "sass:build": "sass --no-source-map src/assets/styles:css",
-    "start": "npm-run-all fetch-theme-colors sass:build bookshop-sass:build --parallel bookshop-sass:watch sass:watch bookshop:browser eleventy:watch"
+    "start": "npm-run-all sass:build bookshop-sass:build --parallel bookshop-sass:watch sass:watch bookshop:browser eleventy:watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eleventy:watch": "ELEVENTY_ENV=development eleventy --serve",
     "sass:watch": "sass --no-source-map --watch src/assets/styles:css",
     "sass:build": "sass --no-source-map src/assets/styles:css",
-    "start": "npm-run-all bookshop-sass:build --parallel bookshop-sass:watch sass:watch bookshop:browser eleventy:watch"
+    "start": "npm-run-all fetch-theme-colors sass:build bookshop-sass:build --parallel bookshop-sass:watch sass:watch bookshop:browser eleventy:watch"
   },
   "repository": {
     "type": "git",

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -27,12 +27,6 @@
   ],
   "google_maps_api_key": null,
   "_inputs": {
-    "light_background_variant": {
-      "type": "color"
-    },
-    "dark_background_variant": {
-      "type": "color"
-    },
     "heading_font": {
       "comment": "Write the name of any font from https://fonts.google.com/ in data/fonts to access it here"
     },

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,7 +1,5 @@
 {
   "styles": {
-    "light_background_variant": "#3b3b3d",
-    "dark_background_variant": "#1b1b1d",
     "heading_font": "Lato",
     "content_font": "Lato"
   },

--- a/src/_data/theme.json
+++ b/src/_data/theme.json
@@ -1,7 +1,7 @@
 {
-    "primary_background_color": "#be0000",
-    "primary_foreground_color": "#f9f9fb",
-    "secondary_background_color": "#1a0037",
-    "secondary_foreground_color": "#dbffd7",
+    "primary_background_color": "#ffffff",
+    "primary_foreground_color": "#000000",
+    "secondary_background_color": "#000000",
+    "secondary_foreground_color": "#ffffff",
     "interaction_color": "#2566f2"
 }

--- a/src/_data/theme.json
+++ b/src/_data/theme.json
@@ -1,0 +1,7 @@
+{
+    "primary_background_color": "#3b3b3d",
+    "primary_foreground_color": "#f9f9fb",
+    "secondary_background_color": "#1b1b1d",
+    "secondary_foreground_color": "#d9d9dc",
+    "interaction_color": "#2566f2"
+}

--- a/src/_data/theme.json
+++ b/src/_data/theme.json
@@ -1,7 +1,7 @@
 {
-    "primary_background_color": "#ffffff",
-    "primary_foreground_color": "#000000",
-    "secondary_background_color": "#000000",
-    "secondary_foreground_color": "#ffffff",
-    "interaction_color": "#2566f2"
+    "primary_background_color": "#004949",
+    "primary_foreground_color": "#f9f100",
+    "secondary_background_color": "#6c0000",
+    "secondary_foreground_color": "#d7ffee",
+    "interaction_color": "#f2a925"
 }

--- a/src/_data/theme.json
+++ b/src/_data/theme.json
@@ -1,7 +1,7 @@
 {
-    "primary_background_color": "#2b0026",
+    "primary_background_color": "#be0000",
     "primary_foreground_color": "#f9f9fb",
-    "secondary_background_color": "#033700",
+    "secondary_background_color": "#1a0037",
     "secondary_foreground_color": "#dbffd7",
     "interaction_color": "#2566f2"
 }

--- a/src/_data/theme.json
+++ b/src/_data/theme.json
@@ -1,6 +1,6 @@
 {
     "primary_background_color": "#004949",
-    "primary_foreground_color": "#f9f100",
+    "primary_foreground_color": "#e7bcbc",
     "secondary_background_color": "#6c0000",
     "secondary_foreground_color": "#d7ffee",
     "interaction_color": "#f2a925"

--- a/src/_data/theme.json
+++ b/src/_data/theme.json
@@ -1,7 +1,7 @@
 {
-    "primary_background_color": "#3b3b3d",
+    "primary_background_color": "#2b0026",
     "primary_foreground_color": "#f9f9fb",
-    "secondary_background_color": "#1b1b1d",
-    "secondary_foreground_color": "#d9d9dc",
+    "secondary_background_color": "#033700",
+    "secondary_foreground_color": "#dbffd7",
     "interaction_color": "#2566f2"
 }

--- a/src/_includes/partials/footer/footer.html
+++ b/src/_includes/partials/footer/footer.html
@@ -10,9 +10,9 @@
     </a>
     <div class="{{ c }}__social-icons">
             {% capture social_icon_styles %}
-                icon_background_hover_color: "var(--brand-grey-200, #E9E9EC)"
-                icon_color: "var(--brand-grey-200, #E9E9EC)"
-                icon_hover_color: "var(--brand-grey-900, #f9f9fb)"
+                icon_background_hover_color: "var(--primary-foreground, #E9E9EC)"
+                icon_color: "var(--primary-foreground, #E9E9EC)"
+                icon_hover_color: "var(--secondary-background, #f9f9fb)"
             {% endcapture %}
             {% assign social_icons_style = social_icon_styles | ymlify %}
             {% bookshop "generic/social-icons" social_media_links:site.social_media_links style:social_icons_style %}

--- a/src/_includes/partials/footer/footer.html
+++ b/src/_includes/partials/footer/footer.html
@@ -10,9 +10,9 @@
     </a>
     <div class="{{ c }}__social-icons">
             {% capture social_icon_styles %}
-                icon_background_hover_color: "var(--primary-foreground-color, #E9E9EC)"
-                icon_color: "var(--primary-foreground-color, #E9E9EC)"
-                icon_hover_color: "var(--secondary-background-color, #f9f9fb)"
+                icon_background_hover_color: "var(--alt-text-color, #E9E9EC)"
+                icon_color: "var(--alt-text-color, #E9E9EC)"
+                icon_hover_color: "var(--alt-background-color, #f9f9fb)"
             {% endcapture %}
             {% assign social_icons_style = social_icon_styles | ymlify %}
             {% bookshop "generic/social-icons" social_media_links:site.social_media_links style:social_icons_style %}

--- a/src/_includes/partials/footer/footer.html
+++ b/src/_includes/partials/footer/footer.html
@@ -10,9 +10,9 @@
     </a>
     <div class="{{ c }}__social-icons">
             {% capture social_icon_styles %}
-                icon_background_hover_color: "var(--primary-foreground, #E9E9EC)"
-                icon_color: "var(--primary-foreground, #E9E9EC)"
-                icon_hover_color: "var(--secondary-background, #f9f9fb)"
+                icon_background_hover_color: "var(--primary-foreground-color, #E9E9EC)"
+                icon_color: "var(--primary-foreground-color, #E9E9EC)"
+                icon_hover_color: "var(--secondary-background-color, #f9f9fb)"
             {% endcapture %}
             {% assign social_icons_style = social_icon_styles | ymlify %}
             {% bookshop "generic/social-icons" social_media_links:site.social_media_links style:social_icons_style %}

--- a/src/_includes/partials/head/stylesheets.html
+++ b/src/_includes/partials/head/stylesheets.html
@@ -1,8 +1,8 @@
 <!-- User Defined Styles -->
 <style>
   :root {
-    --light-background-variant: {{ site.styles.light_background_variant | default: "#3B3B3D" }};
-    --dark-background-variant: {{ site.styles.dark_background_variant | default: "#1B1B1D" }};
+    --primary-background: {{ site.styles.light_background_variant | default: "#3B3B3D" }};
+    --secondary-background: {{ site.styles.dark_background_variant | default: "#1B1B1D" }};
     --heading-font: {{ site.styles.heading_font | default: "Lato" }};
     --content-font: {{ site.styles.content_font | default: "Lato" }};
     --logo-font: {{ nav.logo_text.font | default: "Lato" }};

--- a/src/_includes/partials/head/stylesheets.html
+++ b/src/_includes/partials/head/stylesheets.html
@@ -1,8 +1,6 @@
 <!-- User Defined Styles -->
 <style>
-  :root {
-    --primary-background: {{ site.styles.light_background_variant | default: "#3B3B3D" }};
-    --secondary-background: {{ site.styles.dark_background_variant | default: "#1B1B1D" }};
+  :root {   
     --heading-font: {{ site.styles.heading_font | default: "Lato" }};
     --content-font: {{ site.styles.content_font | default: "Lato" }};
     --logo-font: {{ nav.logo_text.font | default: "Lato" }};

--- a/src/_includes/partials/nav/navigation.html
+++ b/src/_includes/partials/nav/navigation.html
@@ -32,9 +32,9 @@
 
         <div class="{{ c }}__social-icons">
             {% capture social_icon_styles %}
-                icon_background_hover_color: "var(--primary-foreground, #E9E9EC)"
-                icon_color: "var(--primary-foreground, #E9E9EC)"
-                icon_hover_color: "var(--secondary-background, #f9f9fb)"
+                icon_background_hover_color: "var(--primary-foreground-color, #E9E9EC)"
+                icon_color: "var(--primary-foreground-color, #E9E9EC)"
+                icon_hover_color: "var(--secondary-background-color, #f9f9fb)"
             {% endcapture %}
             {% assign social_icons_style = social_icon_styles | ymlify %}
             {% bookshop "generic/social-icons" social_media_links:site.social_media_links style:social_icons_style %}

--- a/src/_includes/partials/nav/navigation.html
+++ b/src/_includes/partials/nav/navigation.html
@@ -32,9 +32,9 @@
 
         <div class="{{ c }}__social-icons">
             {% capture social_icon_styles %}
-                icon_background_hover_color: "var(--primary-foreground-color, #E9E9EC)"
-                icon_color: "var(--primary-foreground-color, #E9E9EC)"
-                icon_hover_color: "var(--secondary-background-color, #f9f9fb)"
+                icon_background_hover_color: "var(--alt-text-color)"
+                icon_color: "var(--alt-text-color)"
+                icon_hover_color: "var(--alt-background-color)"
             {% endcapture %}
             {% assign social_icons_style = social_icon_styles | ymlify %}
             {% bookshop "generic/social-icons" social_media_links:site.social_media_links style:social_icons_style %}

--- a/src/_includes/partials/nav/navigation.html
+++ b/src/_includes/partials/nav/navigation.html
@@ -32,9 +32,9 @@
 
         <div class="{{ c }}__social-icons">
             {% capture social_icon_styles %}
-                icon_background_hover_color: "var(--brand-grey-200, #E9E9EC)"
-                icon_color: "var(--brand-grey-200, #E9E9EC)"
-                icon_hover_color: "var(--brand-grey-900, #f9f9fb)"
+                icon_background_hover_color: "var(--primary-foreground, #E9E9EC)"
+                icon_color: "var(--primary-foreground, #E9E9EC)"
+                icon_hover_color: "var(--secondary-background, #f9f9fb)"
             {% endcapture %}
             {% assign social_icons_style = social_icon_styles | ymlify %}
             {% bookshop "generic/social-icons" social_media_links:site.social_media_links style:social_icons_style %}

--- a/src/assets/styles/component-browser.scss
+++ b/src/assets/styles/component-browser.scss
@@ -1,0 +1,3 @@
+.bookshop-browser-menus, [data-bookshop-browser-section] {
+    color: initial;
+}

--- a/src/assets/styles/footer.scss
+++ b/src/assets/styles/footer.scss
@@ -1,6 +1,6 @@
 .c-footer {
   $c: &;
-  background: var(--brand-grey-900, #1b1b1d);
+  background: var(--secondary-background, #1b1b1d);
   padding: 3.5rem 1rem;
   display: grid;
   gap: 1rem;
@@ -8,7 +8,7 @@
 
   &__logo-link {
     text-decoration: none;
-    color: var(--brand-grey-200, #e9e9ec);
+    color: var(--primary-foreground, #e9e9ec);
     font-family: var(--logo-font), Lato, sans-serif;
     white-space: nowrap;
     font-size: 4.58025rem;
@@ -30,19 +30,19 @@
     &__item {
       &__link {
         text-decoration: none;
-        color: var(--brand-grey-200, #e9e9ec);
+        color: var(--primary-foreground, #e9e9ec);
         white-space: nowrap;
 
         &:hover,
         &:active {
-          border-bottom: 1px solid var(--brand-grey-000, #f9f9fb);
-          color: var(--brand-grey-000, #f9f9fb);
+          border-bottom: 1px solid var(--primary-foreground, #f9f9fb);
+          color: var(--primary-foreground, #f9f9fb);
         }
       }
       &--active {
         #{$c}__navlist__item__link {
-          border-bottom: 1px solid var(--brand-grey-000, #f9f9fb);
-          color: var(--brand-grey-000, #f9f9fb);
+          border-bottom: 1px solid var(--primary-foreground, #f9f9fb);
+          color: var(--primary-foreground, #f9f9fb);
         }
       }
     }

--- a/src/assets/styles/footer.scss
+++ b/src/assets/styles/footer.scss
@@ -1,6 +1,6 @@
 .c-footer {
   $c: &;
-  background: var(--secondary-background-color, #1b1b1d);
+  background: var(--alt-background-color);
   padding: 3.5rem 1rem;
   display: grid;
   gap: 1rem;
@@ -8,7 +8,7 @@
 
   &__logo-link {
     text-decoration: none;
-    color: var(--primary-foreground-color, #e9e9ec);
+    color: var(--alt-text-color);
     font-family: var(--logo-font), Lato, sans-serif;
     white-space: nowrap;
     font-size: 4.58025rem;
@@ -30,19 +30,19 @@
     &__item {
       &__link {
         text-decoration: none;
-        color: var(--primary-foreground-color, #e9e9ec);
+        color: var(--alt-text-color);
         white-space: nowrap;
 
         &:hover,
         &:active {
-          border-bottom: 1px solid var(--primary-foreground-color, #f9f9fb);
-          color: var(--primary-foreground-color, #f9f9fb);
+          border-bottom: 1px solid var(--alt-text-color);
+          color: var(--alt-text-color);
         }
       }
       &--active {
         #{$c}__navlist__item__link {
-          border-bottom: 1px solid var(--primary-foreground-color, #f9f9fb);
-          color: var(--primary-foreground-color, #f9f9fb);
+          border-bottom: 1px solid var(--alt-text-color);
+          color: var(--alt-text-color);
         }
       }
     }
@@ -51,10 +51,10 @@
   &__content {
     padding-top: 7rem;
     text-align: center;
-    color: var(--neutral-000, #FFF);
+    color: var(--alt-text-color);
 
     a {
-      color: var(--neutral-000, #FFF);
+      color: var(--alt-text-color);
     }
   }
 }

--- a/src/assets/styles/footer.scss
+++ b/src/assets/styles/footer.scss
@@ -1,6 +1,6 @@
 .c-footer {
   $c: &;
-  background: var(--secondary-background, #1b1b1d);
+  background: var(--secondary-background-color, #1b1b1d);
   padding: 3.5rem 1rem;
   display: grid;
   gap: 1rem;
@@ -8,7 +8,7 @@
 
   &__logo-link {
     text-decoration: none;
-    color: var(--primary-foreground, #e9e9ec);
+    color: var(--primary-foreground-color, #e9e9ec);
     font-family: var(--logo-font), Lato, sans-serif;
     white-space: nowrap;
     font-size: 4.58025rem;
@@ -30,19 +30,19 @@
     &__item {
       &__link {
         text-decoration: none;
-        color: var(--primary-foreground, #e9e9ec);
+        color: var(--primary-foreground-color, #e9e9ec);
         white-space: nowrap;
 
         &:hover,
         &:active {
-          border-bottom: 1px solid var(--primary-foreground, #f9f9fb);
-          color: var(--primary-foreground, #f9f9fb);
+          border-bottom: 1px solid var(--primary-foreground-color, #f9f9fb);
+          color: var(--primary-foreground-color, #f9f9fb);
         }
       }
       &--active {
         #{$c}__navlist__item__link {
-          border-bottom: 1px solid var(--primary-foreground, #f9f9fb);
-          color: var(--primary-foreground, #f9f9fb);
+          border-bottom: 1px solid var(--primary-foreground-color, #f9f9fb);
+          color: var(--primary-foreground-color, #f9f9fb);
         }
       }
     }

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -2,6 +2,7 @@
 @import "variables.scss";
 @import "nav.scss";
 @import "footer.scss";
+@import "component-browser.scss";
 
 body {
   display: grid;
@@ -9,6 +10,7 @@ body {
   min-height: 100svh;
   grid-template-rows: auto 1fr auto;
   font-family: var(--content-font), Lato, sans-serif;
+  color: var(--main-text-color);
 
   h1,
   h2,
@@ -31,7 +33,6 @@ main {
 .component {
   padding: 96px 0px;
   background-color: var(--main-background-color);
-  color: var(--main-text-color);
 
   &--secondary {
     --main-background-color: var(--secondary-background-color, #1B1B1D);

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -30,10 +30,14 @@ main {
 // Component-specific styles are defined within their component directory
 .component {
   padding: 96px 0px;
-  background-color: var(--primary-background-color);
+  background-color: var(--main-background-color);
+  color: var(--main-text-color);
 
-  &--dark {
-    background-color: var(--secondary-background-color);
+  &--secondary {
+    --main-background-color: var(--secondary-background-color, #1B1B1D);
+    --main-text-color: var(--secondary-foreground-color, #D9D9DC);
+    --alt-background-color: var(--primary-background-color, #3B3B3D);
+    --alt-text-color: var(--primary-foreground-color, #F9F9FB);
   }
 
   &--full-height {

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -30,10 +30,10 @@ main {
 // Component-specific styles are defined within their component directory
 .component {
   padding: 96px 0px;
-  background-color: var(--light-background-variant);
+  background-color: var(--primary-background);
 
   &--dark {
-    background-color: var(--dark-background-variant);
+    background-color: var(--secondary-background);
   }
 
   &--full-height {

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -30,10 +30,10 @@ main {
 // Component-specific styles are defined within their component directory
 .component {
   padding: 96px 0px;
-  background-color: var(--primary-background);
+  background-color: var(--primary-background-color);
 
   &--dark {
-    background-color: var(--secondary-background);
+    background-color: var(--secondary-background-color);
   }
 
   &--full-height {

--- a/src/assets/styles/nav.scss
+++ b/src/assets/styles/nav.scss
@@ -4,13 +4,13 @@
   grid-template-columns: var(--twelve-column-grid);
   grid-template-rows: var(--nav-height) 1fr auto;
   height: auto;
-  background: var(--secondary-background-color);
+  background: var(--alt-background-color);
   --nav-padding: 8px;
 
   &__logo-link {
     grid-column: 2 / -3;
     text-decoration: none;
-    color: var(--primary-foreground-color, #e9e9ec);
+    color: var(--alt-text-color);
     font-family: var(--logo-font), Lato, sans-serif;
     font-size: 2rem;
     line-height: 3.75rem;
@@ -44,19 +44,19 @@
     &__item {
       &__link {
         text-decoration: none;
-        color: var(--primary-foreground-color, #e9e9ec);
+        color: var(--alt-text-color);
         white-space: nowrap;
 
         &:hover,
         &:active {
-          border-bottom: 1px solid var(--primary-foreground-color, #f9f9fb);
-          color: var(--primary-foreground-color, #f9f9fb);
+          border-bottom: 1px solid var(--alt-text-color);
+          color: var(--alt-text-color);
         }
       }
       &--active {
         #{$c}__navlist__item__link {
-          border-bottom: 1px solid var(--primary-foreground-color, #f9f9fb);
-          color: var(--primary-foreground-color, #f9f9fb);
+          border-bottom: 1px solid var(--alt-text-color);
+          color: var(--alt-text-color);
         }
       }
     }
@@ -87,7 +87,7 @@
       height: 3px;
       width: 30px;
       border-radius: 15px;
-      background-color: #ffff;
+      background-color: var(--alt-text-color);
 
       &::before {
         transition: all 0.18s;
@@ -98,7 +98,7 @@
         height: 3px;
         width: 30px;
         border-radius: 15px;
-        background-color: #ffff;
+        background-color: var(--alt-text-color);
       }
 
       &::after {
@@ -110,7 +110,7 @@
         height: 3px;
         width: 30px;
         border-radius: 15px;
-        background-color: #ffff;
+        background-color: var(--alt-text-color);
       }
     }
   }
@@ -123,13 +123,13 @@
       &__burger {
         &::before {
           transform: rotate(45deg);
-          background-color: #ffff;
+          background-color: var(--alt-text-color);
           top: 0;
         }
 
         &::after {
           transform: rotate(-45deg);
-          background-color: #ffff;
+          background-color: var(--alt-text-color);
           top: 0;
         }
 

--- a/src/assets/styles/nav.scss
+++ b/src/assets/styles/nav.scss
@@ -4,13 +4,13 @@
   grid-template-columns: var(--twelve-column-grid);
   grid-template-rows: var(--nav-height) 1fr auto;
   height: auto;
-  background: var(--secondary-background);
+  background: var(--secondary-background-color);
   --nav-padding: 8px;
 
   &__logo-link {
     grid-column: 2 / -3;
     text-decoration: none;
-    color: var(--primary-foreground, #e9e9ec);
+    color: var(--primary-foreground-color, #e9e9ec);
     font-family: var(--logo-font), Lato, sans-serif;
     font-size: 2rem;
     line-height: 3.75rem;
@@ -44,19 +44,19 @@
     &__item {
       &__link {
         text-decoration: none;
-        color: var(--primary-foreground, #e9e9ec);
+        color: var(--primary-foreground-color, #e9e9ec);
         white-space: nowrap;
 
         &:hover,
         &:active {
-          border-bottom: 1px solid var(--primary-foreground, #f9f9fb);
-          color: var(--primary-foreground, #f9f9fb);
+          border-bottom: 1px solid var(--primary-foreground-color, #f9f9fb);
+          color: var(--primary-foreground-color, #f9f9fb);
         }
       }
       &--active {
         #{$c}__navlist__item__link {
-          border-bottom: 1px solid var(--primary-foreground, #f9f9fb);
-          color: var(--primary-foreground, #f9f9fb);
+          border-bottom: 1px solid var(--primary-foreground-color, #f9f9fb);
+          color: var(--primary-foreground-color, #f9f9fb);
         }
       }
     }

--- a/src/assets/styles/nav.scss
+++ b/src/assets/styles/nav.scss
@@ -4,13 +4,13 @@
   grid-template-columns: var(--twelve-column-grid);
   grid-template-rows: var(--nav-height) 1fr auto;
   height: auto;
-  background: var(--header-color);
+  background: var(--secondary-background);
   --nav-padding: 8px;
 
   &__logo-link {
     grid-column: 2 / -3;
     text-decoration: none;
-    color: var(--brand-grey-200, #e9e9ec);
+    color: var(--primary-foreground, #e9e9ec);
     font-family: var(--logo-font), Lato, sans-serif;
     font-size: 2rem;
     line-height: 3.75rem;
@@ -44,19 +44,19 @@
     &__item {
       &__link {
         text-decoration: none;
-        color: var(--brand-grey-200, #e9e9ec);
+        color: var(--primary-foreground, #e9e9ec);
         white-space: nowrap;
 
         &:hover,
         &:active {
-          border-bottom: 1px solid var(--brand-grey-000, #f9f9fb);
-          color: var(--brand-grey-000, #f9f9fb);
+          border-bottom: 1px solid var(--primary-foreground, #f9f9fb);
+          color: var(--primary-foreground, #f9f9fb);
         }
       }
       &--active {
         #{$c}__navlist__item__link {
-          border-bottom: 1px solid var(--brand-grey-000, #f9f9fb);
-          color: var(--brand-grey-000, #f9f9fb);
+          border-bottom: 1px solid var(--primary-foreground, #f9f9fb);
+          color: var(--primary-foreground, #f9f9fb);
         }
       }
     }

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -30,7 +30,7 @@
   /* Colors */
   // User editable theme colors
   --primary-background-color: #004949;
-  --primary-foreground-color: #f9f100;
+  --primary-foreground-color: #e7bcbc;
   --secondary-background-color: #6c0000;
   --secondary-foreground-color: #d7ffee;
 

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -29,10 +29,10 @@
 
   /* Colors */
   // User editable theme colors
-  --primary-background-color: purple;
-  --primary-foreground-color: #000000;
-  --secondary-background-color: red;
-  --secondary-foreground-color: #ffffff;
+  --primary-background-color: #004949;
+  --primary-foreground-color: #f9f100;
+  --secondary-background-color: #6c0000;
+  --secondary-foreground-color: #d7ffee;
 
   // FOR INTERNAL USE
   --main-background-color: var(--primary-background-color, #3B3B3D);
@@ -44,7 +44,7 @@
   --error-color: #bf2323;
 
   // Blue - interaction
-  --interaction-color: #2566f2;
+  --interaction-color: #f2a925;
 
   // Green - success
   --success-color: #0d8843;

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -28,40 +28,20 @@
   --font-weight-bold: 700;
 
   /* Colors */
-  // Gray
-  --brand-grey-000: #f9f9fb;
-  --brand-grey-100: #f2f2f4;
-  --brand-grey-200: #e9e9ec;
-  --brand-grey-300: #d9d9dc;
-  --brand-grey-400: #b6b6b8;
-  --brand-grey-500: #969698;
-  --brand-grey-600: #6e6e70;
-  --brand-grey-700: #5a5a5c;
-  --brand-grey-800: #3b3b3d;
-  --brand-grey-900: #1b1b1d;
-  // Red
-  --error-red-000: #f9e9e9;
-  --error-red-100: #efc8c8;
-  --error-red-200: #df9191;
-  --error-red-300: #bf2323;
-  --error-red-400: #ab1d1d;
-  --error-red-500: #881212;
-  // Blue
-  --interaction-blue-000: #e7eeff;
-  --interaction-blue-100: #c4d4fe;
-  --interaction-blue-200: #92b2f8;
-  --interaction-blue-300: #2566f2;
-  --interaction-blue-400: #1d51c1;
-  --interaction-blue-500: #163d91;
-  // Green
-  --success-green-000: #e7f3ec;
-  --success-green-100: #c2e1d0;
-  --success-green-200: #49a672;
-  --success-green-300: #0d8843;
-  --success-green-400: #017737;
-  --success-green-500: #005824;
+  // User editable theme colors
+  --primary-background-color: #3b3b3d;
+  --primary-foreground-color: #f9f9fb;
+  --secondary-background-color: #1b1b1d;
+  --secondary-foreground-color: #d9d9dc;
 
-  --header-color: #1b1b1d99;
+  // Red - error
+  --error-color: #bf2323;
+
+  // Blue - interaction
+  --interaction-color: #2566f2;
+
+  // Green - success
+  --success-color: #0d8843;
 
   --nav-height: 60px;
 }

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -29,10 +29,16 @@
 
   /* Colors */
   // User editable theme colors
-  --primary-background-color: #2b0026;
-  --primary-foreground-color: #f9f9fb;
-  --secondary-background-color: #033700;
-  --secondary-foreground-color: #dbffd7;
+  --primary-background-color: #fff;
+  --primary-foreground-color: #000;
+  --secondary-background-color: #000;
+  --secondary-foreground-color: #fff;
+
+  // FOR INTERNAL USE
+  --main-background-color: var(--primary-background-color, #3B3B3D);
+  --main-text-color: var(--primary-foreground-color, #F9F9FB);
+  --alt-background-color: var(--secondary-background-color, #1B1B1D);
+  --alt-text-color: var(--secondary-foreground-color, #D9D9DC);
 
   // Red - error
   --error-color: #bf2323;

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -29,10 +29,10 @@
 
   /* Colors */
   // User editable theme colors
-  --primary-background-color: #3b3b3d;
+  --primary-background-color: #2b0026;
   --primary-foreground-color: #f9f9fb;
-  --secondary-background-color: #1b1b1d;
-  --secondary-foreground-color: #d9d9dc;
+  --secondary-background-color: #033700;
+  --secondary-foreground-color: #dbffd7;
 
   // Red - error
   --error-color: #bf2323;

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -29,10 +29,10 @@
 
   /* Colors */
   // User editable theme colors
-  --primary-background-color: #fff;
-  --primary-foreground-color: #000;
-  --secondary-background-color: #000;
-  --secondary-foreground-color: #fff;
+  --primary-background-color: purple;
+  --primary-foreground-color: #000000;
+  --secondary-background-color: red;
+  --secondary-foreground-color: #ffffff;
 
   // FOR INTERNAL USE
   --main-background-color: var(--primary-background-color, #3B3B3D);

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -4,5 +4,57 @@ layout: layouts/page.html
 permalink: /
 draft: false
 eleventyExcludeFromCollections: false
-content_blocks: []
+content_blocks: 
+  - _bookshop_name: sections/centered-large-asset
+    content:
+      heading:
+        _bookshop_name: generic/component-heading
+        eyebrow_headline: Eyebrow Heading
+        primary_heading: Primary Heading
+      description: Description text to compliment the block
+      asset:
+      button:
+        _bookshop_name: generic/button
+        url: '#'
+        open_in_new_tab: false
+        text: Button text
+        variant: primary
+        disabled: true
+        arrow: right
+        onclick:
+    styles:
+      background_variant: light
+  - _bookshop_name: sections/form
+    content:
+      heading:
+        _bookshop_name: generic/component-heading
+        eyebrow_headline: Eyebrow Heading
+        primary_heading: Primary Heading
+      description: Description text to compliment the block
+      form:
+        _bookshop_name: simple/form-builder
+        id: 24e95531-9fc7-409d-b016-18fddd28d51b
+        form_submission_type: email/cloudcannon
+        inbox_key:
+        subject:
+        success_page: ''
+        inputs:
+          - _bookshop_name: generic/form/country-select-input
+            label: ''
+            id: 395f6cb4-69ea-4fd1-a5da-520504cee27b
+            required: false
+            helper_text:
+          - _bookshop_name: generic/form/email-input
+            label: ''
+            id: 9cab361d-9a51-47ea-8c5d-e08100d72af9
+            required: false
+            placeholder: email?
+            helper_text:
+        submit_button:
+          text: Button text
+          variant: primary
+          arrow: right
+    styles:
+      background_variant: light
+      content_alignment: center
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -19,7 +19,7 @@ content_blocks:
         open_in_new_tab: false
         text: Button text
         variant: primary
-        disabled: true
+        disabled: false
         arrow: right
         onclick:
     styles:

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -45,6 +45,22 @@ content_blocks:
             required: false
             placeholder: Placeholder
             helper_text: Please enter an email
+          - _bookshop_name: generic/form/date-input
+            label: ''
+            id: 45f8e626-566a-4c6a-bf4f-9dccf26f18e9
+            required: false
+            min_today: false
+            min:
+            max_today: false
+            max:
+            helper_text:
+          - _bookshop_name: generic/form/time-input
+            label: ''
+            placeholder: ''
+            id: 6c0dc486-1a2e-41c7-a9a4-796956094542
+            helper_text:
+            min: 10:00 am
+            max: 10:02 am
         submit_button:
           text: Button text
           variant: primary
@@ -90,6 +106,6 @@ content_blocks:
         image_path: /uploads/brooke-cagle-8jp-6sjvibm-unsplash.jpg
         image_alt:
     styles:
-      image_alignment: left
+      image_alignment: full
       background_variant: primary
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -4,7 +4,7 @@ layout: layouts/page.html
 permalink: /
 draft: false
 eleventyExcludeFromCollections: false
-content_blocks: 
+content_blocks:
   - _bookshop_name: sections/centered-large-asset
     content:
       heading:
@@ -57,4 +57,6 @@ content_blocks:
     styles:
       background_variant: light
       content_alignment: center
+  - _bookshop_name: generic/sample
+    text:
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -24,4 +24,66 @@ content_blocks:
         onclick:
     styles:
       background_variant: secondary
+  - _bookshop_name: sections/form
+    content:
+      heading:
+        _bookshop_name: generic/component-heading
+        eyebrow_headline: Eyebrow Heading
+        primary_heading: Primary Heading
+      description: Description text to compliment the block
+      form:
+        _bookshop_name: simple/form-builder
+        id: f642d06b-4be8-4a98-b43f-4247046102d9
+        form_submission_type: email/cloudcannon
+        inbox_key:
+        subject:
+        success_page: ''
+        inputs:
+          - _bookshop_name: generic/form/email-input
+            label: Email
+            id: 7c8d7fe8-b02a-4869-abdb-972e5c2e9641
+            required: false
+            placeholder: Placeholder
+            helper_text: Please enter an email
+        submit_button:
+          text: Button text
+          variant: primary
+          arrow: right
+    styles:
+      background_variant: primary
+      content_alignment: center
+  - _bookshop_name: sections/price-list
+    content:
+      heading:
+        _bookshop_name: generic/component-heading
+        eyebrow_headline: Eyebrow Heading
+        primary_heading: Primary Heading
+      description: Description text to compliment the block
+      lists: []
+    styles:
+      background_variant: primary
+      content_alignment: center
+  - _bookshop_name: sections/hero
+    content:
+      heading:
+        _bookshop_name: generic/component-heading
+        eyebrow_headline: Eyebrow Heading
+        primary_heading: Primary Heading
+      description: Description text to compliment the block
+      button:
+        _bookshop_name: generic/button
+        url: '#'
+        open_in_new_tab: false
+        text: Button text
+        variant: primary
+        disabled: false
+        arrow: right
+        onclick:
+      image:
+        _bookshop_name: generic/image
+        image_path: /uploads/brooke-cagle-8jp-6sjvibm-unsplash.jpg
+        image_alt:
+    styles:
+      image_alignment: left
+      background_variant: primary
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -60,7 +60,7 @@ content_blocks:
             id: 6c0dc486-1a2e-41c7-a9a4-796956094542
             helper_text:
             min: 10:00 am
-            max: 10:02 am
+            max: 11:02 am
         submit_button:
           text: Button text
           variant: primary

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -45,6 +45,22 @@ content_blocks:
             required: false
             placeholder: Placeholder
             helper_text: Please enter an email
+          - _bookshop_name: generic/form/date-input
+            label: ''
+            id: 45f8e626-566a-4c6a-bf4f-9dccf26f18e9
+            required: false
+            min_today: false
+            min:
+            max_today: false
+            max:
+            helper_text:
+          - _bookshop_name: generic/form/time-input
+            label: ''
+            placeholder: ''
+            id: 6c0dc486-1a2e-41c7-a9a4-796956094542
+            helper_text:
+            min:
+            max:
         submit_button:
           text: Button text
           variant: primary

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -24,37 +24,4 @@ content_blocks:
         onclick:
     styles:
       background_variant: light
-  - _bookshop_name: sections/form
-    content:
-      heading:
-        _bookshop_name: generic/component-heading
-        eyebrow_headline: Eyebrow Heading
-        primary_heading: Primary Heading
-      description: Description text to compliment the block
-      form:
-        _bookshop_name: simple/form-builder
-        id: 24e95531-9fc7-409d-b016-18fddd28d51b
-        form_submission_type: email/cloudcannon
-        inbox_key:
-        subject:
-        success_page: ''
-        inputs:
-          - _bookshop_name: generic/form/country-select-input
-            label: ''
-            id: 395f6cb4-69ea-4fd1-a5da-520504cee27b
-            required: false
-            helper_text:
-          - _bookshop_name: generic/form/email-input
-            label: ''
-            id: 9cab361d-9a51-47ea-8c5d-e08100d72af9
-            required: false
-            placeholder: email?
-            helper_text:
-        submit_button:
-          text: Button text
-          variant: primary
-          arrow: right
-    styles:
-      background_variant: light
-      content_alignment: center
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -59,8 +59,8 @@ content_blocks:
             placeholder: ''
             id: 6c0dc486-1a2e-41c7-a9a4-796956094542
             helper_text:
-            min:
-            max:
+            min: 10:00 am
+            max: 10:00 am
         submit_button:
           text: Button text
           variant: primary

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -23,5 +23,5 @@ content_blocks:
         arrow: right
         onclick:
     styles:
-      background_variant: dark
+      background_variant: secondary
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -59,7 +59,13 @@ content_blocks:
         eyebrow_headline: Eyebrow Heading
         primary_heading: Primary Heading
       description: Description text to compliment the block
-      lists: []
+      lists:
+        - list_heading: List heading
+          list_items:
+            - label: List item
+              detail: $$
+            - label: List item
+              detail: $$
     styles:
       background_variant: primary
       content_alignment: center

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -57,6 +57,4 @@ content_blocks:
     styles:
       background_variant: light
       content_alignment: center
-  - _bookshop_name: generic/sample
-    text:
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -23,5 +23,5 @@ content_blocks:
         arrow: right
         onclick:
     styles:
-      background_variant: light
+      background_variant: dark
 ---

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -24,4 +24,27 @@ content_blocks:
         onclick:
     styles:
       background_variant: secondary
+  - _bookshop_name: sections/hero
+    content:
+      heading:
+        _bookshop_name: generic/component-heading
+        eyebrow_headline: Eyebrow Heading
+        primary_heading: Primary Heading
+      description: Description text to compliment the block
+      button:
+        _bookshop_name: generic/button
+        url: '#'
+        open_in_new_tab: false
+        text: Button text
+        variant: primary
+        disabled: false
+        arrow: right
+        onclick:
+      image:
+        _bookshop_name: generic/image
+        image_path: /uploads/brooke-cagle-8jp-6sjvibm-unsplash.jpg
+        image_alt:
+    styles:
+      image_alignment: left
+      background_variant: primary
 ---

--- a/utils/fetch-theme-colors.js
+++ b/utils/fetch-theme-colors.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+
+// read theme color from _data/site.json
+fs.readFile('src/_data/theme.json', 'utf8', (err, dataFile) => {
+    
+    if(err){
+        console.log(err);
+        return;
+    }
+    
+    // parse file to JSON so that the variables can be accessed
+    dataFile = JSON.parse(dataFile);
+
+    const variableFileLocation = './src/assets/styles/variables.scss'
+
+    fs.readFile(variableFileLocation, 'utf-8', (err, cssFile) => {
+
+        if(err){
+            console.log(err);
+            return;
+        }
+
+        let replaced = cssFile;
+
+        // Change the variables to whatever was set in the data file
+        Object.entries(dataFile).forEach(([k,v]) => {
+            k = k.split("_").join("-");
+            const re = new RegExp(`--${k}: .*`, 'g')
+            replaced = replaced.replace(re,`--${k}: ${v};`)
+        })
+
+        // Write result back to variables.css
+        fs.writeFile(variableFileLocation, replaced, 'utf-8', err => {
+            if(err)
+                console.log(err);
+            
+            console.log(`📚 Writing variables to ${variableFileLocation}`)
+        });
+    });
+
+})


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Colors-1b796a45066d46d3aacafb3134f609f2)

# Additional information

Fairly major refactor to allow for users to edit the theme colours.

- theme.yml changed to theme.json and fetch-theme-colors script added into prebuild steps
- allows for primary background/foreground colours, secondary background/foreground colours, as well as interaction colour to be updated by user
- error/success colours not editable by user
- light/dark options in style changed to primary/secondary

# Testing (tester)

Suggested testing: 

- check with extreme contrast colours to see obvious errors
- pairings should work together -black background/white foreground etc 
- so check with opposite pairings for primary/secondary... e.g. black for primary foreground AND black for secondary background... white for primary background AND white for secondary foreground - this should identify 'invisible' elements where incorrect variables have been used (e.g. white on white)

The reviewer should check on this branch:

- The code
- The site in CloudCannon [Link here](https://app.cloudcannon.com/42158/editor#sites/118797/dashboard/summary:/edit?editor=visual&url=%2F&collection=pages)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
