### PR TITLE
Test/Fix: only add min/max if they are set

### DIFF
--- a/component-library/components/generic/form/time-input/time-input.eleventy.liquid
+++ b/component-library/components/generic/form/time-input/time-input.eleventy.liquid
@@ -5,8 +5,8 @@
         type="time" id="{{ id }}" 
         name="{{ label }}" 
         value="{{ placeholder }}"
-        min="{{ min | militaryTime }}"
-        max="{{ max | militaryTime }}"
+        {% if min %}min="{{ min | militaryTime }}"{% endif %}
+        {% if max %}max="{{ max | militaryTime }}"{% endif %}
         onblur="validateInput(this)"
         oninput="validateInputTyping(this)"
         {% if helper_text %}aria-describedby="{{ id }}--helper"{% endif %}>


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Fix-time-input-live-editing-1631a13e90764329b96d202488989823?pvs=4)

# Additional information

On main adding a time input gets the red box for something being broken. Just added a check around min/max to see if they are set and seems to be fixed.

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon ([link here](https://app.cloudcannon.com/42158/editor#sites/118821/collections/pages/))

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
