### PR TITLE
Remove disabled property from generic button

### DIFF
--- a/component-library/components/generic/button/button.bookshop.yml
+++ b/component-library/components/generic/button/button.bookshop.yml
@@ -1,7 +1,6 @@
 # Metadata about this component, to be used in the CMS
 spec:
   structures:
-    - content_blocks
   label: "Button"
   description: Link to another location with the style of a button
   icon: smart_button

--- a/component-library/components/generic/button/button.bookshop.yml
+++ b/component-library/components/generic/button/button.bookshop.yml
@@ -1,6 +1,7 @@
 # Metadata about this component, to be used in the CMS
 spec:
   structures:
+    - content_blocks
   label: "Button"
   description: Link to another location with the style of a button
   icon: smart_button

--- a/component-library/components/generic/button/button.bookshop.yml
+++ b/component-library/components/generic/button/button.bookshop.yml
@@ -12,7 +12,6 @@ blueprint:
   open_in_new_tab: false
   text: "Button text"
   variant: "primary"
-  disabled: false
   arrow: "right"
   onclick: 
 
@@ -21,7 +20,6 @@ preview:
   url: "#"
   text: "Button text"
   variant: "primary"
-  disabled: false
   arrow: "right"
   onclick: console.log(this)
 

--- a/component-library/components/generic/button/button.eleventy.liquid
+++ b/component-library/components/generic/button/button.eleventy.liquid
@@ -2,14 +2,14 @@
 {% assign_local arrow_type = "arrow-" | append: arrow %}
 
 {% if url and url!=''%}
-    <a href="{{ url }}" class="{{c}} {{c}}--{{ variant }}" {% if disabled %}disabled{% endif %} {% if open_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %}>
+    <a href="{{ url }}" class="{{c}} {{c}}--{{ variant }}" {% if open_in_new_tab %}target="_blank" rel="noopener noreferrer"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %}>
         {{ text }}
         {% if arrow %}
             {% bookshop "generic/icon" hero_icon_name:arrow_type icon_type:"solid" icon_size:'extra-small'  color:'transparent' %}
         {% endif %}
     </a>
 {% else %}
-    <button class="{{c}} {{c}}--{{ variant }}" {% if disabled %}disabled{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %}>
+    <button class="{{c}} {{c}}--{{ variant }}" {% if onclick %}onclick="{{ onclick }}"{% endif %}>
         {{ text }}
         {% if arrow %}
             {% bookshop "generic/icon" hero_icon_name:arrow_type icon_type:"solid" icon_size:'extra-small'  color:'transparent' %}

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -34,7 +34,6 @@ preview:
       open_in_new_tab: false
       text: Primary
       variant: primary
-      disabled: false
       arrow: right
       onclick: console.log(this)
     description: "We wanted you to have a couple of options to use above the fold, and give you the customisation you need to display your product/service in the best way possible."

--- a/component-library/components/simple/card/card.eleventy.liquid
+++ b/component-library/components/simple/card/card.eleventy.liquid
@@ -35,7 +35,7 @@
         <div class="{{c}}__content">{% bookshop "generic/text-block" text:content.text %}</div>
         {% if content.button %}
             <div class="{{ c }}__button">
-                {% bookshop "generic/button" url:content.button.url text:content.button.text open_in_new_tab:content.button.open_in_new_tab variant:"secondary" disabled:false arrow:"right"%}
+                {% bookshop "generic/button" url:content.button.url text:content.button.text open_in_new_tab:content.button.open_in_new_tab variant:"secondary" arrow:"right"%}
             </div>
         {% endif %}
     </div>

--- a/component-library/components/simple/gallery/gallery.eleventy.liquid
+++ b/component-library/components/simple/gallery/gallery.eleventy.liquid
@@ -13,6 +13,6 @@
             {% endfor %}
         </div>
 
-        <div class="c-gallery__button">{% bookshop "generic/button" text:"Load More" variant:"primary" disabled:false arrow:"down" %}</div>
+        <div class="c-gallery__button">{% bookshop "generic/button" text:"Load More" variant:"primary" arrow:"down" %}</div>
     {% endif %}
 </div>


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Remove-disabled-button-option-style-fadfb9ba42624042abd201e39909452f?pvs=4)

# Additional information

Check the button still works without this property. Button is used in Hero, Card, and Gallery components so you could also check them.

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon ([link here](https://app.cloudcannon.com/42158/editor#sites/119058/dashboard/summary))

# Before merge (PR owner)

- [x] Delete the test site in CloudCannon
- [x] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
