### PR TITLE
add skip nav

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -1,12 +1,12 @@
 source: src
 paths:
   data: _data
-  collections: ''
+  collections: ""
   layouts: _includes
-  static: ''
+  static: ""
   uploads: uploads
   includes: _includes
-  pages: ''
+  pages: ""
 collections_config:
   data:
     path: _data
@@ -54,7 +54,7 @@ _inputs:
       allow_empty: false
       value_key: id
       preview:
-        text: 
+        text:
           - key: name
         icon:
           - key: icon
@@ -71,7 +71,7 @@ _inputs:
       allow_empty: false
       value_key: id
       preview:
-        text: 
+        text:
           - key: name
         icon:
           - key: icon
@@ -382,6 +382,8 @@ _inputs:
   show_note:
     type: switch
     comment: Hide/Show the note that contains helpful information about the live editing of this component
+  skipnav_text:
+    comment: A hidden link at the top of the page that, when activated, jumps the user to the beginning of the main content area.
 _select_data: {}
 _structures:
   content_blocks:

--- a/src/_data/nav.yml
+++ b/src/_data/nav.yml
@@ -1,4 +1,4 @@
-logo_image: ''
+logo_image: ""
 logo_text:
   text: Primera Mesa
   font: Birthstone Bounce
@@ -15,3 +15,4 @@ navigation_items:
   - label: Contact Us
     link_url: /contact
     open_in_new_tab: false
+skipnav_text: "Skip to contents"

--- a/src/_includes/layouts/page.html
+++ b/src/_includes/layouts/page.html
@@ -13,7 +13,7 @@
     </head>
     <body>
         {% include 'partials/nav/navigation.html' %}
-        <main>
+        <main id="main">
             {% bookshop_include "page" content_blocks: content_blocks %}
             {{ content }}
         </main>

--- a/src/_includes/partials/nav/navigation.html
+++ b/src/_includes/partials/nav/navigation.html
@@ -2,7 +2,9 @@
 
 <header>
     <nav class="{{c}}" aria-label="Main menu" id="main-menu">
-
+        <a class="{{c}}__skip-to-content-link" href="#main">
+            Skip to content
+        </a>
         <a class="{{c}}__logo-link" href="/" aria-label="Home" {% if page.url=="/" %}aria-current="page" {% endif %}>
             {% if nav.logo_image != '' %}
                 <img class="{{c}}__logo-link__image" src="{{nav.logo_image}}" alt="Site logo" />

--- a/src/_includes/partials/nav/navigation.html
+++ b/src/_includes/partials/nav/navigation.html
@@ -1,10 +1,16 @@
-{% assign c = "c-navigation" %}
-
+{% assign_local c = "c-navigation" %}
+{% assign skipnav_text = nav.skipnav_text | default: "Skip to contents" %}
 <header>
     <nav class="{{c}}" aria-label="Main menu" id="main-menu">
-        <a class="{{c}}__skip-to-content-link" href="#main">
-            Skip to content
-        </a>
+        <div class="{{c}}__skip-to-content-link" >
+            {% bookshop "generic/button"
+                url: '#main'
+                text:skipnav_text
+                variant: "primary"
+                arrow: "down"
+            %}
+        </div>
+
         <a class="{{c}}__logo-link" href="/" aria-label="Home" {% if page.url=="/" %}aria-current="page" {% endif %}>
             {% if nav.logo_image != '' %}
                 <img class="{{c}}__logo-link__image" src="{{nav.logo_image}}" alt="Site logo" />
@@ -16,7 +22,6 @@
         <button class="{{ c }}__burger-menu" id="main-menu-toggle">
             <div class="{{ c }}__burger-menu__burger"></div>
         </button>
-
         <ul class="{{ c }}__navlist">
             {% for navitem in nav.navigation_items %}
                 {% assign nav_item_with_slash = navitem.link_url | append: "/" %}
@@ -42,4 +47,6 @@
             {% bookshop "generic/social-icons" social_media_links:site.social_media_links style:social_icons_style _liveRender:false %}
         </div>
     </nav>
+
+
 </header>

--- a/src/assets/styles/nav.scss
+++ b/src/assets/styles/nav.scss
@@ -7,16 +7,16 @@
   background: var(--alt-background-color);
   --nav-padding: 8px;
   &__skip-to-content-link {
-    background: var(--primary-foreground-color);
-    // height: 30px;
-    left: 50%;
-    padding: 1rem;
-    position: absolute;
-    transform: translateY(-100%);
-    transition: transform 0.3s;
-    border-radius: 0 0 1rem 1rem;
-    &:focus {
-      transform: translateY(0%);
+    // background: var(--primary-foreground-color);
+    .c-button {
+      left: 45%;
+      position: absolute;
+      transform: translateY(-100%);
+      transition: transform 0.3s;
+      border-radius: 0 0 1rem 1rem;
+      &:focus {
+        transform: translateY(0%);
+      }
     }
   }
   &__logo-link {

--- a/src/assets/styles/nav.scss
+++ b/src/assets/styles/nav.scss
@@ -6,7 +6,19 @@
   height: auto;
   background: var(--alt-background-color);
   --nav-padding: 8px;
-
+  &__skip-to-content-link {
+    background: var(--primary-foreground-color);
+    // height: 30px;
+    left: 50%;
+    padding: 1rem;
+    position: absolute;
+    transform: translateY(-100%);
+    transition: transform 0.3s;
+    border-radius: 0 0 1rem 1rem;
+    &:focus {
+      transform: translateY(0%);
+    }
+  }
   &__logo-link {
     grid-column: 2 / -3;
     text-decoration: none;


### PR DESCRIPTION
# Context

[Link ](https://www.notion.so/cloudcannon/Skip-to-content-button-29f7a3030f574425895fa533323bc68b?pvs=4)to Notion ticket

# Additional information

We need allow users to skip the navigation when tabbing through the site. 

# Testing (tester)

The reviewer should check on this branch:
Tab the site and you should be able to click the skip tab link 

- The code
- The site in CloudCannon (https://flora-gnu.cloudvent.net/#main)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
