### PR TITLE
Hide blocks if they dont exist

### DIFF
--- a/component-library/components/sections/form/form.eleventy.liquid
+++ b/component-library/components/sections/form/form.eleventy.liquid
@@ -4,10 +4,12 @@
                 component--secondary
             {% endif %}" >
 
-    <div class="{{ c }}__heading">
-        {% if content.heading %}{% bookshop "generic/component-heading" bind:content.heading %}{% endif %}
-        {% if content.description %}{% bookshop "generic/text-block" text:content.description %}{% endif %}
-    </div>
+    {% if content.heading or content.description %}
+        <div class="{{ c }}__heading">
+            {% if content.heading %}{% bookshop "generic/component-heading" bind:content.heading %}{% endif %}
+            {% if content.description %}{% bookshop "generic/text-block" text:content.description %}{% endif %}
+        </div>
+    {% endif %}
 
     <div class="{{ c }}__form">
         {% bookshop "simple/form-builder" bind:content.form %}

--- a/component-library/components/sections/hero/hero.eleventy.liquid
+++ b/component-library/components/sections/hero/hero.eleventy.liquid
@@ -5,11 +5,16 @@
             {% endif %}">
     {% bookshop "generic/image" bind:content.image %}
     <div class="{{ c }}__cover"></div>
-    <div class="{{ c }}__content">
-        {% if content.heading %}{% bookshop "generic/component-heading" bind:content.heading %}{% endif %}
-        {% if content.description %}{% bookshop "generic/text-block" text:content.description %}{% endif %}
-        <div class="{{ c }}__content__button">
-            {% if content.button %}{% bookshop "generic/button" bind:content.button %}{% endif %}
+
+    {% if content.heading or content.description or content.button %}
+        <div class="{{ c }}__content">
+            {% if content.heading %}{% bookshop "generic/component-heading" bind:content.heading %}{% endif %}
+            {% if content.description %}{% bookshop "generic/text-block" text:content.description %}{% endif %}
+            {% if content.button %}
+                <div class="{{ c }}__content__button">
+                    {% bookshop "generic/button" bind:content.button %}
+                </div>
+            {% endif %}
         </div>
-    </div>
+    {% endif %}
 </section>

--- a/component-library/components/sections/price-list/price-list.eleventy.liquid
+++ b/component-library/components/sections/price-list/price-list.eleventy.liquid
@@ -3,11 +3,13 @@
             {% if styles.background_variant == 'secondary' %} 
                 component--secondary
             {% endif %}">
-    
-    <div class="{{ pl }}__heading">
-        {% if content.heading %}{% bookshop "generic/component-heading" bind:content.heading %}{% endif %}
-        {% if content.description %}{% bookshop "generic/text-block" text:content.description %}{% endif %}
-    </div>
+
+    {% if content.heading or content.description %}
+        <div class="{{ pl }}__heading">
+            {% if content.heading %}{% bookshop "generic/component-heading" bind:content.heading %}{% endif %}
+            {% if content.description %}{% bookshop "generic/text-block" text:content.description %}{% endif %}
+        </div>
+    {% endif %}
 
     <div class="{{ pl }}__lists">
         {% for list in content.lists %}

--- a/component-library/components/sections/simple-text-block/simple-text-block.eleventy.liquid
+++ b/component-library/components/sections/simple-text-block/simple-text-block.eleventy.liquid
@@ -5,8 +5,11 @@
 {% if styles.background_variant == 'secondary' %} 
     component--secondary
 {% endif %} '>
+
+{% if content.heading or content.text %}
     <div class='{{c}}__content'>
         {% bookshop "generic/component-heading" bind:content.heading %}
         {% bookshop "generic/text-block" bind:content.text %}
     </div>
+{% endif %}
 </section>


### PR DESCRIPTION
# Context

Link to [Notion ticket](https://www.notion.so/cloudcannon/Hide-blocks-if-they-dont-exist-c169079719c34ac5b7f7fd16c8b6bdcb?pvs=4)

# Additional information
I left left/right blocks and image grid card out.

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon (link here)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
