### PR TITLE
Feat: add simple left right block

### DIFF
--- a/component-library/components/generic/left-right-block/left-right-block.bookshop.yml
+++ b/component-library/components/generic/left-right-block/left-right-block.bookshop.yml
@@ -11,12 +11,13 @@ blueprint:
   heading: bookshop:generic/component-heading
   social_icons: bookshop:generic/social-icons 
   contact_details:
-  author_name:
+  text:
   buttons: [bookshop:generic/button]
   icons: [bookshop:generic/labelled-icon]
   image: bookshop:generic/image
   map: bookshop:simple/google-map-embed
   image_alignment: Left
+  image_padding: false
   background_variant: primary
 
 
@@ -33,7 +34,7 @@ preview:
         svg_icon: /assets/images/icons/social/youtube.svg
   contact_details: >-
     This is a simple yet powerful block to display not only your location by using Google Maps, but also any other contact details you wish to share with your customers.
-  author_name: John Smith
+  text: John Smith
   buttons:
     url: "#"
     open_in_new_tab: false

--- a/component-library/components/generic/left-right-block/left-right-block.eleventy.liquid
+++ b/component-library/components/generic/left-right-block/left-right-block.eleventy.liquid
@@ -1,6 +1,6 @@
 {% assign_local c = "c-left-right-block" %}
 
-<div class="{{ c }} component component--full-height {% if styles.image_alignment == "Right" %}{{ c }}--right{% endif %} {% if styles.background_variant == "secondary" %} 
+<div class="{{ c }} component {% if image_padding != true %}component--full-height{% endif %} {% if styles.image_alignment == "Right" %}{{ c }}--right{% endif %} {% if styles.background_variant == "secondary" %} 
   component--secondary
 {% endif %}">
   <div class="{{ c }}__content">
@@ -16,10 +16,10 @@
           {{ contact_details | markdownify }}
         </div>
       {% endif %}
-      {% if author_name %}
-        <p class="{{ c }}__content-text">
-          {{ author_name }}
-        </p>
+      {% if text %}
+        <div class="{{ c }}__content-text">
+          {% bookshop "generic/text-block" bind:text %}
+        </div>
       {% endif %}
       {% if icons %}
         <div class="{{ c }}__icons">
@@ -37,7 +37,7 @@
       {% endif %}
     </div>
   </div>
-  <div class="{{ c }}__media">
+  <div class="{{ c }}__media {% if image_padding %}{{ c }}__media--auto-height{% endif %}">
     {% if image %}
       {% bookshop "generic/image" bind: image %}
     {% endif %}

--- a/component-library/components/generic/left-right-block/left-right-block.scss
+++ b/component-library/components/generic/left-right-block/left-right-block.scss
@@ -3,14 +3,20 @@
 
   display: grid;
   grid-template-columns: var(--twelve-column-grid);
+  padding-bottom: 0;
 
   .c-component-heading {
     margin-bottom: 0.5rem;
   }
 
   &__content {
-    padding: 3rem 0;
+    padding-bottom: 3rem;
     grid-column: 2 / -2;
+  }
+  &.component--full-height {
+    #{$c}__content {
+      padding: 3rem 0;
+    }
   }
 
   &__content-text {
@@ -59,12 +65,15 @@
 
   // Desktop styles
   @media screen and (min-width: 1279px) {
+    padding-bottom: 6rem;
+
     &__content {
       padding: 0;
       grid-column: 9 / -2;
       align-self: center;
     }
     &.component--full-height {
+      padding-bottom: 0;
       &__content {
         padding: 6rem 0;
       }

--- a/component-library/components/generic/left-right-block/left-right-block.scss
+++ b/component-library/components/generic/left-right-block/left-right-block.scss
@@ -46,8 +46,8 @@
   }
 
   &__media {
-    aspect-ratio: 1 / 1;
     grid-column: 1 / -1;
+    max-height: 700px;
   }
 
   & .c-image,
@@ -60,18 +60,27 @@
   // Desktop styles
   @media screen and (min-width: 1279px) {
     &__content {
+      padding: 0;
       grid-column: 9 / -2;
       align-self: center;
-      padding: 6rem 0;
+    }
+    &.component--full-height {
+      &__content {
+        padding: 6rem 0;
+      }
     }
 
     &__media  {
       grid-column: 1 / 8;
       grid-row: 1;
       justify-self: end;
-      height: 100%;
-      max-height: 700px;
+      max-width: 700px;
+      max-height: unset;
       align-self: center;
+
+      &--auto-height {
+        height: auto;
+      }
     }
 
     &--right {

--- a/component-library/components/sections/left-right-block--simple/left-right-block--simple.bookshop.yml
+++ b/component-library/components/sections/left-right-block--simple/left-right-block--simple.bookshop.yml
@@ -1,0 +1,38 @@
+# Metadata about this component, to be used in the CMS
+spec:
+  structures:
+    - content_blocks
+  label: "Left/Right - Simple"
+  description: Heading, text and buttons with supporting image
+  icon: article
+  tags: []
+
+# Defines the structure of this component, as well as the default values
+blueprint:
+  content:
+    heading: bookshop:generic/component-heading
+    text:
+    buttons: [bookshop:generic/button]
+    image: bookshop:generic/image
+  styles:
+    image_padding: true
+    image_alignment: Left
+    background_variant: primary
+
+# Overrides any fields in the blueprint when viewing this component in the component browser
+preview:
+  content:
+    text: A classic component, you can select to have your image to the left or the right, add a button or two, and give the viewer a quick intro to your brand.
+
+# Any extra CloudCannon inputs configuration to apply to the blueprint
+_inputs:
+  image_padding:
+    type: switch
+  text:
+    type: textarea
+  image_alignment:
+    type: select
+    options:
+      values:
+        - Left
+        - Right  

--- a/component-library/components/sections/left-right-block--simple/left-right-block--simple.bookshop.yml
+++ b/component-library/components/sections/left-right-block--simple/left-right-block--simple.bookshop.yml
@@ -10,10 +10,10 @@ spec:
 # Defines the structure of this component, as well as the default values
 blueprint:
   content:
-    heading: bookshop:generic/component-heading
-    text: bookshop:generic/text-block
+    heading: bookshop:generic/component-heading!
+    text: bookshop:generic/text-block!
     buttons: [bookshop:generic/button]
-    image: bookshop:generic/image
+    image: bookshop:generic/image!
   styles:
     image_padding: true
     image_alignment: Left

--- a/component-library/components/sections/left-right-block--simple/left-right-block--simple.bookshop.yml
+++ b/component-library/components/sections/left-right-block--simple/left-right-block--simple.bookshop.yml
@@ -11,7 +11,7 @@ spec:
 blueprint:
   content:
     heading: bookshop:generic/component-heading
-    text:
+    text: bookshop:generic/text-block
     buttons: [bookshop:generic/button]
     image: bookshop:generic/image
   styles:
@@ -22,14 +22,15 @@ blueprint:
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:
   content:
-    text: A classic component, you can select to have your image to the left or the right, add a button or two, and give the viewer a quick intro to your brand.
+    text:
+      _bookshop_name: generic/text-block
+      text: >-
+        A classic component, you can select to have your image to the left or the right, add a button or two, and give the viewer a quick intro to your brand.
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:
   image_padding:
     type: switch
-  text:
-    type: textarea
   image_alignment:
     type: select
     options:

--- a/component-library/components/sections/left-right-block--simple/left-right-block--simple.eleventy.liquid
+++ b/component-library/components/sections/left-right-block--simple/left-right-block--simple.eleventy.liquid
@@ -1,0 +1,5 @@
+{% assign_local c = "c-left-right-block--simple" %}
+
+<section class="{{ c }}">
+  {% bookshop "generic/left-right-block" heading:content.heading buttons:content.buttons text:content.text image:content.image image_alignment:styles.image_alignment background_variant:styles.background_variant image_padding:styles.image_padding %}
+</section>

--- a/component-library/components/sections/left-right-block--simple/left-right-block--simple.scss
+++ b/component-library/components/sections/left-right-block--simple/left-right-block--simple.scss
@@ -1,0 +1,3 @@
+.c-left-right-block--simple {
+
+}

--- a/component-library/components/sections/left-right-block--testimonial/left-right-block--testimonial.eleventy.liquid
+++ b/component-library/components/sections/left-right-block--testimonial/left-right-block--testimonial.eleventy.liquid
@@ -8,5 +8,5 @@
 
 
 <section class="{{ c }}">
-  {% bookshop "generic/left-right-block" heading:heading buttons:content.buttons author_name:content.author_name image:content.image image_alignment:styles.image_alignment background_variant:styles.background_variant %}
+  {% bookshop "generic/left-right-block" heading:heading buttons:content.buttons text:content.author_name image:content.image image_alignment:styles.image_alignment background_variant:styles.background_variant %}
 </section>


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Left-right-block-feature-ba543c301a4346189b813032ea618d77?pvs=4)
[Link to Notion ticket](https://www.notion.so/cloudcannon/Left-right-images-should-always-be-700px-not-max-700px-888a066faba94d609e2197d661a612a7?pvs=4)

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon ([link here](https://app.cloudcannon.com/42158/editor#sites/119121/setup))

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] Delete blocks from pages
