### PR TITLE
Add structure icon

### DIFF
--- a/component-library/components/generic/custom-icon/custom-icon.bookshop.yml
+++ b/component-library/components/generic/custom-icon/custom-icon.bookshop.yml
@@ -1,6 +1,7 @@
 # Metadata about this component, to be used in the CMS
 spec:
   structures:
+    - icons
   label: "Custom Icon"
   description: An icon (that you upload) with an optional border and customisable color
   icon: bolt

--- a/component-library/components/generic/custom-icon/custom-icon.bookshop.yml
+++ b/component-library/components/generic/custom-icon/custom-icon.bookshop.yml
@@ -1,7 +1,7 @@
 # Metadata about this component, to be used in the CMS
 spec:
   structures:
-    - icons
+    - icon_blocks
   label: "Custom Icon"
   description: An icon (that you upload) with an optional border and customisable color
   icon: bolt

--- a/component-library/components/generic/icon/icon.bookshop.yml
+++ b/component-library/components/generic/icon/icon.bookshop.yml
@@ -2,7 +2,7 @@
 spec:
   structures:
     - card_imagery_blocks
-    - icons
+    - icon_blocks
   label: "Icon"
   description: A icon (from https://heroicons.com/) with an optional border and customisable color
   icon: bolt

--- a/component-library/components/generic/icon/icon.bookshop.yml
+++ b/component-library/components/generic/icon/icon.bookshop.yml
@@ -2,6 +2,7 @@
 spec:
   structures:
     - card_imagery_blocks
+    - icons
   label: "Icon"
   description: A icon (from https://heroicons.com/) with an optional border and customisable color
   icon: bolt

--- a/component-library/components/generic/labelled-icon/labelled-icon.bookshop.yml
+++ b/component-library/components/generic/labelled-icon/labelled-icon.bookshop.yml
@@ -10,7 +10,7 @@ spec:
 blueprint:
   arrangement: inline
   text: 
-  icon: bookshop:generic/icon!
+  icon: bookshop:structure:icons
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:

--- a/component-library/components/generic/labelled-icon/labelled-icon.bookshop.yml
+++ b/component-library/components/generic/labelled-icon/labelled-icon.bookshop.yml
@@ -10,7 +10,7 @@ spec:
 blueprint:
   arrangement: inline
   text: 
-  icon: bookshop:structure:icons
+  icon: bookshop:structure:icon_blocks
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:

--- a/component-library/components/generic/labelled-icon/labelled-icon.eleventy.liquid
+++ b/component-library/components/generic/labelled-icon/labelled-icon.eleventy.liquid
@@ -2,7 +2,7 @@
 
 <div class="{{ c }} {{ c }}--{{ arrangement }}">
     {% if icon %}        
-      {% bookshop "generic/icon" bind:icon %}
+      {% bookshop "{{icon._bookshop_name}}" bind:icon %}
     {% endif %}
     <p class="{{ c }}__text">{{ text }}</p>
 </div>


### PR DESCRIPTION
# Context

Link to [Notion ticket
](https://www.notion.so/cloudcannon/Allow-custom-icon-in-labelled-icon-e0b0837b1495438084b8db6c10bd8649?pvs=4)
# Additional information

What does the reviewer need to know about the implementation or how to test this PR.

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon (link here)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
