### PR TITLE
Refactor/lat lng comment

### DIFF
--- a/component-library/components/simple/google-map-embed/google-map-embed.bookshop.yml
+++ b/component-library/components/simple/google-map-embed/google-map-embed.bookshop.yml
@@ -20,8 +20,6 @@ preview:
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:
-  $:
-    comment: Trying it out
   zoom_level:
     type: range
     options:

--- a/component-library/components/simple/google-map-embed/google-map-embed.bookshop.yml
+++ b/component-library/components/simple/google-map-embed/google-map-embed.bookshop.yml
@@ -26,3 +26,5 @@ _inputs:
       step: 1
       max: 13
       min: 0
+  latitude:
+    comment: "Note: you will have to provide the latitude and longitude coordinates of the location you want to show. See [this guide](https://support.google.com/maps/answer/18539?hl=en&co=GENIE.Platform%3DDesktop) for info on how to find the coordinates in Google Maps."

--- a/component-library/components/simple/google-map-embed/google-map-embed.bookshop.yml
+++ b/component-library/components/simple/google-map-embed/google-map-embed.bookshop.yml
@@ -20,6 +20,8 @@ preview:
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:
+  $:
+    comment: Trying it out
   zoom_level:
     type: range
     options:

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -6,40 +6,27 @@ draft: false
 eleventyExcludeFromCollections: false
 hero:
 content_blocks:
-  - _bookshop_name: sections/simple-text-block
+  - _bookshop_name: sections/left-right-block--featured-map
     content:
       id:
-      heading:
-        _bookshop_name: generic/heading
-        eyebrow_headline: Eyebrow Heading
-        eyebrow_headline_hierarchy: h3
-        primary_heading: Primary Heading
-        primary_heading_hierarchy: h2
-      text:
-        _bookshop_name: generic/text-block
-        text: 🐢
-    styles:
-      color_group: primary0
-  - _bookshop_name: sections/left-right-block--simple
-    content:
-      id:
-      heading:
-        _bookshop_name: generic/heading
-        eyebrow_headline: Eyebrow Heading
-        eyebrow_headline_hierarchy: h3
-        primary_heading: Primary Heading
-        primary_heading_hierarchy: h2
-      text:
-        _bookshop_name: generic/text-block
-        text: 
+      display_social_icons: true
+      show_note: true
+      heading: A contact block
+      description: >-
+        This is a simple yet powerful block to display not only your location by
+        using Google Maps, but also any other contact details you wish to share
+        with your customers.
+      contact_details:
+        - _type: Email
+          text: 'Email address: mybusiness@business.com'
+          hero_icon_name: envelope
+      map:
+        _bookshop_name: simple/google-map-embed
+        latitude:
+        longitude:
+        zoom_level: 9
       buttons: []
-      image:
-        _bookshop_name: generic/image
-        image_path:
-        image_alt:
-        image_sizes:
     styles:
-      image_padding: true
-      image_alignment: Left
+      map_alignment: Left
       color_group: ''
 ---


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Map-lat-long-1c8a32ad71c143978cb04887cee47d16)

# Additional information

- Just added a comment to the latitude input with a link to how the user can find their coordinates
- Attempted a tricky CC hack with Ross's help to make the comment appear at the top of both inputs, rather than just against latitude - but it failed :(

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon [(link here)](https://app.cloudcannon.com/42158/editor#sites/119588/dashboard/summary:/edit?editor=visual&url=%2F&collection=pages)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
