### PR TITLE
Chore/dev note

### DIFF
--- a/component-library/components/generic/social-icons/social-icons.bookshop.yml
+++ b/component-library/components/generic/social-icons/social-icons.bookshop.yml
@@ -8,6 +8,7 @@ spec:
 
 # Defines the structure of this component, as well as the default values
 blueprint:
+  show_note: true
   social_media_links:
     - link_url: https://www.youtube.com/
       icon_path: /assets/images/icons/social/youtube.svg
@@ -18,8 +19,7 @@ blueprint:
     - link_url: https://www.twitter.com/
       icon_path: /assets/images/icons/social/x.svg
     - link_url: https://www.instagram.com/
-      icon_path: /assets/images/icons/social/instagram.svg
-  show_note: true
+      icon_path: /assets/images/icons/social/instagram.svg  
   style:
     icon_background_hover_color: "#7d7f7c"
     icon_color: "#7d7f7c"
@@ -27,6 +27,7 @@ blueprint:
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:
+  show_note: true
   social_media_links:
     - link_url: https://www.youtube.com/
       icon_path: /assets/images/icons/social/youtube.svg

--- a/component-library/components/sections/embed/embed.bookshop.yml
+++ b/component-library/components/sections/embed/embed.bookshop.yml
@@ -10,18 +10,19 @@ spec:
 # Defines the structure of this component, as well as the default values
 blueprint:
   content:
+    show_note: true
     id:
     heading: bookshop:generic/heading!
     description: Description text to compliment the block
     embed: bookshop:generic/custom-embed!
     button: bookshop:generic/button
-    show_note: true
   styles:
     color_group: "" 
     content_alignment: center
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:
+  show_note: true
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:

--- a/component-library/components/sections/grid--gallery-images/grid--gallery-images.bookshop.yml
+++ b/component-library/components/sections/grid--gallery-images/grid--gallery-images.bookshop.yml
@@ -14,6 +14,7 @@ blueprint:
     heading: bookshop:generic/heading!
     description: Description text to compliment the block
     gallery: bookshop:simple/gallery!
+    show_note: true
   styles:
     color_group: "" 
     content_alignment: center
@@ -30,6 +31,7 @@ preview:
       small business template has you covered. Add your services to the list
       below, as many as you like, and let people contact you or book now.
     gallery: bookshop:simple/gallery
+    show_note: false
   styles:
     color_group: "" 
     content_alignment: center

--- a/component-library/components/sections/grid--gallery-images/grid--gallery-images.bookshop.yml
+++ b/component-library/components/sections/grid--gallery-images/grid--gallery-images.bookshop.yml
@@ -10,11 +10,11 @@ spec:
 # Defines the structure of this component, as well as the default values
 blueprint:
   content:
+    show_note: true
     id:
     heading: bookshop:generic/heading!
     description: Description text to compliment the block
     gallery: bookshop:simple/gallery!
-    show_note: true
   styles:
     color_group: "" 
     content_alignment: center
@@ -22,6 +22,7 @@ blueprint:
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:
   content:
+    show_note: true
     heading:
       _bookshop_name: generic/heading
       eyebrow_headline: EYEBROW HEADLINE
@@ -31,7 +32,6 @@ preview:
       small business template has you covered. Add your services to the list
       below, as many as you like, and let people contact you or book now.
     gallery: bookshop:simple/gallery
-    show_note: false
   styles:
     color_group: "" 
     content_alignment: center

--- a/component-library/components/sections/grid--gallery-images/grid--gallery-images.eleventy.liquid
+++ b/component-library/components/sections/grid--gallery-images/grid--gallery-images.eleventy.liquid
@@ -9,6 +9,6 @@
     {% endif %}
 
     <div class="{{ c }}__gallery">
-        {% bookshop "simple/gallery" bind:content.gallery %}
+        {% bookshop "simple/gallery" bind:content.gallery show_note:content.show_note %}
     </div>
 </section>

--- a/component-library/components/sections/left-right-block--featured-map/left-right-block--featured-map.bookshop.yml
+++ b/component-library/components/sections/left-right-block--featured-map/left-right-block--featured-map.bookshop.yml
@@ -10,9 +10,9 @@ spec:
 # Defines the structure of this component, as well as the default values
 blueprint:
   content:
+    show_note: true
     id:
     display_social_icons: true
-    show_note: true
     heading: A contact block
     description: This is a simple yet powerful block to display not only your location by using Google Maps, but also any other contact details you wish to share with your customers.
     contact_details:
@@ -28,8 +28,8 @@ blueprint:
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:
   content:
+    show_note: true
     display_social_icons: true
-    show_note: false
     heading: A contact block
     content: Content
     contact_details:

--- a/component-library/components/simple/gallery/gallery.bookshop.yml
+++ b/component-library/components/simple/gallery/gallery.bookshop.yml
@@ -16,6 +16,7 @@ blueprint:
 
 # Overrides any fields in the blueprint when viewing this component in the component browser
 preview:
+  show_note: true
   images:
     - bookshop:generic/image
     - bookshop:generic/image

--- a/component-library/components/simple/gallery/gallery.bookshop.yml
+++ b/component-library/components/simple/gallery/gallery.bookshop.yml
@@ -8,6 +8,7 @@ spec:
 
 # Defines the structure of this component, as well as the default values
 blueprint:
+  show_note: true
   images: [bookshop:generic/image]
   button:
     text: Load More
@@ -24,6 +25,8 @@ preview:
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:
+  show_note:
+    hidden: true
   images:
     comment: The images should be square in shape
   variant:

--- a/component-library/components/simple/gallery/gallery.bookshop.yml
+++ b/component-library/components/simple/gallery/gallery.bookshop.yml
@@ -8,7 +8,6 @@ spec:
 
 # Defines the structure of this component, as well as the default values
 blueprint:
-  show_note: true
   images: [bookshop:generic/image]
   button:
     text: Load More

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -5,5 +5,72 @@ permalink: /
 draft: false
 eleventyExcludeFromCollections: false
 hero:
-content_blocks: []
+content_blocks:
+  - _bookshop_name: sections/grid--gallery-images
+    content:
+      id:
+      heading:
+        _bookshop_name: generic/heading
+        eyebrow_headline: Eyebrow Heading
+        eyebrow_headline_hierarchy: h3
+        primary_heading: Primary Heading
+        primary_heading_hierarchy: h2
+      description: Description text to compliment the block
+      gallery:
+        _bookshop_name: simple/gallery
+        show_note: true
+        images:
+          - _bookshop_name: generic/image
+            image_path: /assets/images/Hero--background-feature-3.png
+            image_alt:
+            image_sizes:
+        button:
+          text: Load More
+          variant: primary
+      show_note: true
+    styles:
+      color_group: ''
+      content_alignment: center
+  - _bookshop_name: sections/embed
+    content:
+      id:
+      heading:
+        _bookshop_name: generic/heading
+        eyebrow_headline: Eyebrow Heading
+        eyebrow_headline_hierarchy: h3
+        primary_heading: Primary Heading
+        primary_heading_hierarchy: h2
+      description: Description text to compliment the block
+      embed:
+        _bookshop_name: generic/custom-embed
+        embed:
+        ratio: default
+      button:
+      show_note: true
+    styles:
+      color_group: ''
+      content_alignment: center
+  - _bookshop_name: sections/left-right-block--featured-map
+    content:
+      id:
+      display_social_icons: true
+      show_note: true
+      heading: A contact block
+      description: >-
+        This is a simple yet powerful block to display not only your location by
+        using Google Maps, but also any other contact details you wish to share
+        with your customers.
+      contact_details:
+        - _type: Email
+          text: 'Email address: mybusiness@business.com'
+          hero_icon_name: envelope
+      map:
+        _bookshop_name: simple/google-map-embed
+        latitude:
+        longitude:
+        zoom_level: 9
+      buttons: []
+    styles:
+      color_group: ''
+      image_alignment: left
 ---


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Dev-note-inconsistent-appearances-492cfa2ae00a4dabbfbbcc7efcd44b7c)

# Additional information

- Really just 1 move - grid-gallery-images -> added the show_note option to this, and hid it on the child gallery (removing it seemed to break)

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon [(link here)](https://app.cloudcannon.com/42158/editor#sites/119614/dashboard/summary:/edit?editor=visual&url=%2F&collection=pages&path=%2Fsrc%2Fpages%2Findex.html)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
