### PR TITLE
Feat: aria labels added to social icons

### DIFF
--- a/component-library/components/generic/social-icons/social-icons.bookshop.yml
+++ b/component-library/components/generic/social-icons/social-icons.bookshop.yml
@@ -11,14 +11,19 @@ blueprint:
   social_media_links:
     - link_url: https://www.youtube.com/
       icon_path: /assets/images/icons/social/youtube.svg
+      label: Youtube
     - link_url: https://www.facebook.com/
       icon_path: /assets/images/icons/social/facebook.svg
+      label: Facebook
     - link_url: https://www.linkedin.com/
       icon_path: /assets/images/icons/social/linkedin.svg
+      label: LinekdIn
     - link_url: https://www.twitter.com/
       icon_path: /assets/images/icons/social/x.svg
+      label: Twitter
     - link_url: https://www.instagram.com/
       icon_path: /assets/images/icons/social/instagram.svg
+      label: Instagram
   show_note: true
   style:
     icon_background_hover_color: "#7d7f7c"
@@ -30,17 +35,24 @@ preview:
   social_media_links:
     - link_url: https://www.youtube.com/
       icon_path: /assets/images/icons/social/youtube.svg
+      label: Youtube
     - link_url: https://www.facebook.com/
       icon_path: /assets/images/icons/social/facebook.svg
+      label: Facebook
     - link_url: https://www.linkedin.com/
       icon_path: /assets/images/icons/social/linkedin.svg
+      label: LinekdIn
     - link_url: https://www.twitter.com/
       icon_path: /assets/images/icons/social/x.svg
+      label: Twitter
     - link_url: https://www.instagram.com/
       icon_path: /assets/images/icons/social/instagram.svg
+      label: Instagram
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:
+  label:
+    comment: This is a hidden accesibility label used by screen readers to describe what the link is
   social_media_links:
     type: array
     options:

--- a/component-library/components/generic/social-icons/social-icons.eleventy.liquid
+++ b/component-library/components/generic/social-icons/social-icons.eleventy.liquid
@@ -5,7 +5,7 @@
         {% bookshop "generic/notification" heading:"Social Icons" text:"This is where your social icons will appear in the live site, but will not show in live editing in CloudCannon <br> You can edit the icons and their details in /data/site <br> This note will only show in live editing" %}
     {% endif %}
     {% for item in social_media_links %}
-          <a class="{{ c }}__icon" href="{{ item.link_url }}" target="_blank" rel="noopener noreferrer">
+          <a class="{{ c }}__icon" href="{{ item.link_url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ item.label | default: 'social media link' }}">
               {% bookshop "generic/custom-icon" icon_path:item.icon_path icon_size:'small' icon_type:'solid' rounded_border:true color:'transparent' %}
           </a>
     {% endfor %}

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -3,23 +3,28 @@
   "social_media_links": [
     {
       "link_url": "https://www.youtube.com/",
-      "icon_path": "/assets/images/icons/social/youtube.svg"
+      "icon_path": "/assets/images/icons/social/youtube.svg",
+      "label": "Youtube"
     },
     {
       "link_url": "https://www.facebook.com/",
-      "icon_path": "/assets/images/icons/social/facebook.svg"
+      "icon_path": "/assets/images/icons/social/facebook.svg",
+      "label": "Facebook"
     },
     {
       "link_url": "https://www.linkedin.com/",
-      "icon_path": "/assets/images/icons/social/linkedin.svg"
+      "icon_path": "/assets/images/icons/social/linkedin.svg",
+      "label": "LinkedIn"
     },
     {
       "link_url": "https://www.twitter.com/",
-      "icon_path": "/assets/images/icons/social/x.svg"
+      "icon_path": "/assets/images/icons/social/x.svg",
+      "label": "Twitter"
     },
     {
       "link_url": "https://www.instagram.com/",
-      "icon_path": "/assets/images/icons/social/instagram.svg"
+      "icon_path": "/assets/images/icons/social/instagram.svg",
+      "label": "Instagram"
     }
   ],
   "google_maps_api_key": null,


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Accessibility-Social-Icons-need-aria-labels-f5dee5be12764a88b174219188167ba8?pvs=4)

# Additional information

- Added label input to the blue print of the social-icons component
- Social icons component uses the label prop as an aria label. If there isn't a label defined then the aria label will fall back to social media link by default
- Updated social_media_links in site.json to include the new label field

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon ([link here](https://app.cloudcannon.com/42158/editor#sites/119625/setup))

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
