### PR TITLE
Chore/remove components page

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -18,7 +18,10 @@ collections_config:
   pages:
     path: pages
     output: true
-    filter: strict
+    filter:
+      base: strict
+      exclude:
+        - components.html
     icon: description
     disable_add: false
     disable_add_folder: false

--- a/src/pages/components.html
+++ b/src/pages/components.html
@@ -1,7 +1,7 @@
 ---
 title: Components
 permalink: /components/
-draft: false
+draft: true
 eleventyExcludeFromCollections: true
 ---
 


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Remove-components-page-79861c37ab024a10b9182576842ca96f)

# Additional information

- Set components.html draft = true, so you get a 404 when trying to browse to /components
- Set exclude filter in cloudcannon config file so components does not appear in the page collection

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon [(link here)](https://app.cloudcannon.com/42158/editor#sites/119813/collections/pages/)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
