### PR TITLE
Fix/hero subtext

### DIFF
--- a/component-library/components/generic/heading/heading.bookshop.yml
+++ b/component-library/components/generic/heading/heading.bookshop.yml
@@ -37,4 +37,4 @@ _inputs:
         - h1
         - h2
         - h3
-        - h4
+        - h4git 

--- a/component-library/components/generic/heading/heading.bookshop.yml
+++ b/component-library/components/generic/heading/heading.bookshop.yml
@@ -5,8 +5,6 @@ spec:
   description: Header text for your content
   icon: view_headline
   tags: []
-  preview:
-    text: Testing the preview
 
 # Defines the structure of this component, as well as the default values
 blueprint:

--- a/component-library/components/generic/heading/heading.bookshop.yml
+++ b/component-library/components/generic/heading/heading.bookshop.yml
@@ -5,12 +5,14 @@ spec:
   description: Header text for your content
   icon: view_headline
   tags: []
+  preview:
+    text: Testing the preview
 
 # Defines the structure of this component, as well as the default values
 blueprint:
   eyebrow_headline: Eyebrow Heading
-  eyebrow_headline_hierarchy: h3
   primary_heading: Primary Heading
+  eyebrow_headline_hierarchy: h3
   primary_heading_hierarchy: h2
 
 

--- a/component-library/components/generic/heading/heading.bookshop.yml
+++ b/component-library/components/generic/heading/heading.bookshop.yml
@@ -8,10 +8,10 @@ spec:
 
 # Defines the structure of this component, as well as the default values
 blueprint:
-  eyebrow_headline: Eyebrow Heading
-  eyebrow_headline_hierarchy: h3
   primary_heading: Primary Heading
   primary_heading_hierarchy: h2
+  eyebrow_headline: Eyebrow Heading
+  eyebrow_headline_hierarchy: h3
 
 
 # Overrides any fields in the blueprint when viewing this component in the component browser

--- a/component-library/components/generic/heading/heading.bookshop.yml
+++ b/component-library/components/generic/heading/heading.bookshop.yml
@@ -37,4 +37,4 @@ _inputs:
         - h1
         - h2
         - h3
-        - h4git 
+        - h4

--- a/component-library/components/generic/heading/heading.bookshop.yml
+++ b/component-library/components/generic/heading/heading.bookshop.yml
@@ -8,10 +8,10 @@ spec:
 
 # Defines the structure of this component, as well as the default values
 blueprint:
-  primary_heading: Primary Heading
-  primary_heading_hierarchy: h2
   eyebrow_headline: Eyebrow Heading
   eyebrow_headline_hierarchy: h3
+  primary_heading: Primary Heading
+  primary_heading_hierarchy: h2
 
 
 # Overrides any fields in the blueprint when viewing this component in the component browser

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -67,9 +67,3 @@ _inputs:
         - name: Full
           id: full-background
           icon: open_in_full
-  eyebrow_headline:
-    type: text
-    options:
-      preview:
-        subtext:
-          - key: description

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -27,10 +27,10 @@ preview:
   content:
     heading:
       _bookshop_name: generic/heading
-      eyebrow_headline: a small business template
-      eyebrow_headline_hierarchy: h3
       primary_heading: Empower Your Business with This Brilliant Template
       primary_heading_hierarchy: h2
+      eyebrow_headline: a small business template
+      eyebrow_headline_hierarchy: h3
     button:
       url: "#"
       open_in_new_tab: false

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -27,10 +27,10 @@ preview:
   content:
     heading:
       _bookshop_name: generic/heading
-      primary_heading: Empower Your Business with This Brilliant Template
-      primary_heading_hierarchy: h2
       eyebrow_headline: a small business template
       eyebrow_headline_hierarchy: h3
+      primary_heading: Empower Your Business with This Brilliant Template
+      primary_heading_hierarchy: h2
     button:
       url: "#"
       open_in_new_tab: false

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -67,3 +67,11 @@ _inputs:
         - name: Full
           id: full-background
           icon: open_in_full
+preview:
+  text:
+    - "Hero"
+  subtext:
+    - heading.primary_heading
+    - heading.eyebrow_headline
+    - description
+    - "Description text duplicating the component description"

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -43,12 +43,6 @@ preview:
       _bookshop_name: generic/image
       image_path: /assets/images/Testimonial--background-feature.png
       image_alt: A woman laughing
-  text:
-    - key: content.heading.eyebrow_headline
-    - Fallback text
-  subtext:
-    - heading.primary_heading
-    - heading.eyebrow_headline
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:
@@ -73,3 +67,9 @@ _inputs:
         - name: Full
           id: full-background
           icon: open_in_full
+  eyebrow_headline:
+    type: text
+    options:
+      preview:
+        subtext:
+          - key: description

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -43,6 +43,13 @@ preview:
       _bookshop_name: generic/image
       image_path: /assets/images/Testimonial--background-feature.png
       image_alt: A woman laughing
+  text:
+    - "Hero"
+  subtext:
+    - heading.primary_heading
+    - heading.eyebrow_headline
+    - description
+    - "Description text duplicating the component description"
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:
@@ -67,11 +74,3 @@ _inputs:
         - name: Full
           id: full-background
           icon: open_in_full
-preview:
-  text:
-    - "Hero"
-  subtext:
-    - heading.primary_heading
-    - heading.eyebrow_headline
-    - description
-    - "Description text duplicating the component description"

--- a/component-library/components/sections/hero/hero.bookshop.yml
+++ b/component-library/components/sections/hero/hero.bookshop.yml
@@ -44,12 +44,11 @@ preview:
       image_path: /assets/images/Testimonial--background-feature.png
       image_alt: A woman laughing
   text:
-    - "Hero"
+    - key: content.heading.eyebrow_headline
+    - Fallback text
   subtext:
     - heading.primary_heading
     - heading.eyebrow_headline
-    - description
-    - "Description text duplicating the component description"
 
 # Any extra CloudCannon inputs configuration to apply to the blueprint
 _inputs:

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -13,9 +13,9 @@ hero:
   content:
     heading:
       _bookshop_name: generic/heading
-      eyebrow_headline: Eyebrow Heading
-      eyebrow_headline_hierarchy: h3
+      eyebrow_headline:
       primary_heading: Primary Heading
+      eyebrow_headline_hierarchy: h3
       primary_heading_hierarchy: h2
     description: Description text to compliment the block
     button:

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -9,5 +9,26 @@ permalink: /
 draft: false
 eleventyExcludeFromCollections: false
 hero:
+  _bookshop_name: sections/hero
+  content:
+    heading:
+      _bookshop_name: generic/heading
+      eyebrow_headline: Eyebrow Heading
+      eyebrow_headline_hierarchy: h3
+      primary_heading: Primary Heading
+      primary_heading_hierarchy: h2
+    description: Description text to compliment the block
+    button:
+      _bookshop_name: generic/button
+      url: '#'
+      open_in_new_tab: false
+      text: Button text
+      variant: primary
+      arrow: right
+      onclick:
+    image:
+  styles:
+    image_alignment: left
+    color_group: primary
 content_blocks:
 ---


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Hero-subtext-12dcc88de2914f718a556c9a74481e65)

# Additional information

- CC bug
- If no eyebrow specified, CC looks to next field in the blueprint to display in the sidebar preview
- Previously, this was the hierarchy input (h3) which was MEANT to be hidden (thus, shouldn't have shown at all)
- Solution was to move the h3 field lower, so the next field chosen is primary heading
- Currently if BOTH eyebrow and primary heading are blank, will still show h3... but chances of this are much less than before
- And if the heading is deleted entirely, h3 doesn't show... so cases where this will be an issue are minimal.
- Filing an app ticket and calling it a day on this one :)

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon [(link here)](https://app.cloudcannon.com/42158/editor#sites/119770/dashboard/summary:/edit?editor=visual&url=%2F&collection=pages)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
