### PR TITLE
Chore/rename button

### DIFF
--- a/component-library/components/generic/button/button.eleventy.liquid
+++ b/component-library/components/generic/button/button.eleventy.liquid
@@ -1,4 +1,4 @@
-{% assign_local c = "c-button-temp" %}
+{% assign_local c = "c-button" %}
 {% assign_local arrow_type = "arrow-" | append: arrow %}
 
 {% if url and url!=''%}

--- a/component-library/components/generic/button/button.scss
+++ b/component-library/components/generic/button/button.scss
@@ -1,4 +1,4 @@
-.c-button-temp {
+.c-button {
   $c: &;
   all: unset;
   padding: 1rem 0.75rem;

--- a/src/assets/js/gallery.js
+++ b/src/assets/js/gallery.js
@@ -20,7 +20,7 @@ galleries.forEach(gallery => {
     let paginateCardAmount = window.innerWidth >= 769 ? 6 : 3
     let showCards = paginateCards(0, paginateCardAmount, tiles, totalTiles, button)
 
-    gallery.querySelector('.c-button-temp').addEventListener("click", e => {
+    gallery.querySelector('.c-button').addEventListener("click", e => {
         showCards = paginateCards(showCards, paginateCardAmount, tiles, totalTiles, button)
     });
 });

--- a/src/assets/styles/nav.scss
+++ b/src/assets/styles/nav.scss
@@ -32,7 +32,7 @@
   }
 
   &__skip-to-content-link {
-    .c-button-temp {
+    .c-button {
       left: 45%;
       position: absolute;
       transform: translateY(-100%);


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Button-class-name-66ec708a19bd41ba91557a8847a9f09f)

# Additional information

- We renamed the button back from c-button-temp to c-button - confirm that it isn't still blue in CC Beta.

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon [(link here)](https://app.cloudcannon.com/42158/editor#sites/119869/dashboard/summary:/edit?editor=visual&url=%2F&collection=pages)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
