### PR TITLE
feat/add draft comment

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -105,6 +105,7 @@ _inputs:
     hidden: true
   draft:
     type: switch
+    comment: If this is switched on, this page will not appear on the live site
   page_description:
     comment: If empty, defaults to the description set in the SEO data file
   featured_image:

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -1,4 +1,5 @@
 ---
+draft: false
 title: Home
 page_description:
 featured_image:
@@ -6,7 +7,6 @@ featured_image:
   image_alt:
 layout: layouts/page.html
 permalink: /
-draft: false
 eleventyExcludeFromCollections: false
 hero:
 content_blocks: []


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Add-note-about-draft-toggle-9255dcfad3cf4ebeb7598b547e78851c)

# Additional information

- We moved the draft switch to the very top of the page options
- Also added a brief comment about its functionality

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon [(link here)](https://app.cloudcannon.com/42158/editor#sites/119870/dashboard/summary:/edit?editor=visual&url=%2F&collection=pages)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
