### PR TITLE
Chore/components page

### DIFF
--- a/src/_includes/partials/head/meta.html
+++ b/src/_includes/partials/head/meta.html
@@ -31,5 +31,5 @@
 <link rel="canonical" href="{{ site.base_url }}{{ page.url | url }}" />
 
 {% if .title == "Components" %}
-<meta name=”robots” content=”noindex”>
+<meta name="robots" content="noindex">
 {% endif %}

--- a/src/_includes/partials/head/meta.html
+++ b/src/_includes/partials/head/meta.html
@@ -29,3 +29,7 @@
 
 {%- comment -%} Canonical URL for SEO {%- endcomment -%}
 <link rel="canonical" href="{{ site.base_url }}{{ page.url | url }}" />
+
+{% if .title == "Components" %}
+<meta name=”robots” content=”noindex”>
+{% endif %}

--- a/src/pages/components.html
+++ b/src/pages/components.html
@@ -1,7 +1,7 @@
 ---
 title: Components
 permalink: /components/
-draft: true
+draft: false
 eleventyExcludeFromCollections: true
 ---
 


### PR DESCRIPTION
# Context

[Link to Notion ticket](https://www.notion.so/cloudcannon/Component-library-page-broken-5e9bf51ea7934333a42a3ec35401c8ae)

# Additional information

- the components page is back to draft:false
- the components page also gets `<meta name=”robots” content=”noindex”>` added to the head - I assume this is all that's needed?

# Testing (tester)

The reviewer should check on this branch:

- The code
- The component in Bookshop browser
- The site in CloudCannon [(link here)](https://winged-eraser.cloudvent.net/components/)

# Before merge (PR owner)

- [ ] Delete the test site in CloudCannon
- [ ] For "generic" components **only**: remove `- content_blocks` from `structures` in the YAML file (this was added for testing).
